### PR TITLE
Update kindlegen version to 2.9.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
       rubyzip (>= 1.1.1)
     hashery (2.1.1)
     json (1.8.1)
-    kindlegen (2.9.3)
+    kindlegen (2.9.4)
     mini_portile (0.6.0)
     nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)


### PR DESCRIPTION
如我在 Issue #70 中提到的那样，`kindlegen` 这个工具需要升级到 `2.9.4`。

Ref: https://github.com/progit/progit2/commit/6ee0f656