### PR TITLE
Add PDF CJK theme, fix #48

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,8 @@ gem 'json'
 gem 'awesome_print'
 
 gem 'asciidoctor-epub3', '1.0.0.alpha.2'
-gem 'asciidoctor-pdf', '1.5.0.alpha.5'
+gem 'asciidoctor-pdf', '1.5.0.alpha.8'
+gem 'asciidoctor-pdf-cjk-kai_gen_gothic', '~> 0.1.0'
 
 gem 'coderay'
 gem 'pygments.rb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,21 +2,31 @@ GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (1.0.2)
+    addressable (2.3.8)
     afm (0.2.2)
     asciidoctor (1.5.0)
     asciidoctor-epub3 (1.0.0.alpha.2)
       asciidoctor (>= 1.5.0, < 1.6.0)
       gepub (~> 0.6.9.2)
       thread_safe (~> 0.3.4)
-    asciidoctor-pdf (1.5.0.alpha.5)
+    asciidoctor-pdf (1.5.0.alpha.8)
       asciidoctor (~> 1.5.0)
-      prawn (= 1.2.1)
-      prawn-svg (= 0.16.0)
-      prawn-table (= 0.1.1)
+      prawn (>= 1.3.0, < 3.0.0)
+      prawn-icon (= 0.6.4)
+      prawn-svg (= 0.20.0)
+      prawn-table (= 0.2.1)
       prawn-templates (= 0.0.3)
+      safe_yaml (= 1.0.4)
+      thread_safe (= 0.3.4)
       treetop (= 1.5.3)
+    asciidoctor-pdf-cjk (0.1.1)
+      asciidoctor-pdf (~> 1.5.0.alpha.8)
+    asciidoctor-pdf-cjk-kai_gen_gothic (0.1.0)
+      asciidoctor-pdf-cjk (~> 0.1.1)
     awesome_print (1.2.0)
     coderay (1.1.0)
+    css_parser (1.3.6)
+      addressable
     epubcheck (3.0.1)
     gepub (0.6.9.2)
       nokogiri (~> 1.6.1)
@@ -27,7 +37,7 @@ GEM
     mini_portile (0.6.0)
     nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
-    pdf-core (0.2.5)
+    pdf-core (0.5.1)
     pdf-reader (1.3.3)
       Ascii85 (~> 1.0.0)
       afm (~> 0.2.0)
@@ -36,12 +46,15 @@ GEM
       ttfunk
     polyglot (0.3.5)
     posix-spawn (0.3.9)
-    prawn (1.2.1)
-      pdf-core (~> 0.2.5)
-      ttfunk (~> 1.2.0)
-    prawn-svg (0.16.0)
-      prawn (>= 0.8.4)
-    prawn-table (0.1.1)
+    prawn (2.0.1)
+      pdf-core (~> 0.5.1)
+      ttfunk (~> 1.4.0)
+    prawn-icon (0.6.4)
+      prawn (>= 1.1.0, < 3.0.0)
+    prawn-svg (0.20.0)
+      css_parser (~> 1.3)
+      prawn (>= 0.8.4, < 3)
+    prawn-table (0.2.1)
     prawn-templates (0.0.3)
       pdf-reader (~> 1.3)
       prawn (>= 0.15.0)
@@ -51,10 +64,11 @@ GEM
     rake (10.3.2)
     ruby-rc4 (0.1.5)
     rubyzip (1.1.6)
+    safe_yaml (1.0.4)
     thread_safe (0.3.4)
     treetop (1.5.3)
       polyglot (~> 0.3)
-    ttfunk (1.2.2)
+    ttfunk (1.4.0)
     yajl-ruby (1.1.0)
 
 PLATFORMS
@@ -63,7 +77,8 @@ PLATFORMS
 DEPENDENCIES
   asciidoctor (= 1.5.0)
   asciidoctor-epub3 (= 1.0.0.alpha.2)
-  asciidoctor-pdf (= 1.5.0.alpha.5)
+  asciidoctor-pdf (= 1.5.0.alpha.8)
+  asciidoctor-pdf-cjk-kai_gen_gothic (~> 0.1.0)
   awesome_print
   coderay
   epubcheck
@@ -72,3 +87,6 @@ DEPENDENCIES
   pygments.rb
   rake
   thread_safe
+
+BUNDLED WITH
+   1.10.5

--- a/README.asc
+++ b/README.asc
@@ -28,7 +28,15 @@
 
 你可以在 http://git-scm.com/book[]找到当前构建，详情请见 https://progit.org[]。
 
-另一个生成电子书文件的方法是使用 Asciidoctor 手动完成。如果你运行下面的命令，你_可能_获得 HTML、Epub、Mobi 和 PDF 输出文件：
+另一个生成电子书文件的方法是使用 Asciidoctor 手动完成。
+
+首先安装中文字体（只需运行一次）：
+
+----
+$ asciidoctor-pdf-cjk-kai_gen_gothic-install
+----
+
+然后运行下面的命令，你_可能_获得 HTML、Epub、Mobi 和 PDF 输出文件：
 
 ----
 $ bundle install

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ namespace :book do
     puts " -- Mobi output at progit.mobi"
 
     puts "Converting to PDF... (this one takes a while)"
-    `bundle exec asciidoctor-pdf progit.asc 2>/dev/null`
+    `bundle exec asciidoctor-pdf -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicCN progit.asc 2>/dev/null`
     puts " -- PDF  output at progit.pdf"
   end
 end


### PR DESCRIPTION
给 asciidoctor-pdf 打了补丁，并且做了一个主题，使用 KaiGen Gothic 字体（https://github.com/akiratw/kaigen-gothic ）。这是一个用 Adobe 思源字体转的 TTF 格式字体，asciidoctor-pdf 依赖的 Prawn 不支持 OTF 格式所以用不了原版。

效果：

![1](https://cloud.githubusercontent.com/assets/49931/8637961/5f377d86-28dd-11e5-875c-78bd24090355.png)
![2](https://cloud.githubusercontent.com/assets/49931/8637962/5f37d790-28dd-11e5-8e52-8d49785e6ae1.png)
![3](https://cloud.githubusercontent.com/assets/49931/8637963/5f38b4a8-28dd-11e5-994a-123feadf3a77.png)

用法：

bundle 之后运行一次 `asciidoctor-pdf-cjk-kai_gen_gothic-install` 命令，安装字体。字体总共 140 多 MB，有点大。

之后 `rake book:build` 就行了。