### PR TITLE
Update TRANSLATION_NOTES.asc: Add Agreement about Git Objects Translation

### DIFF
--- a/TRANSLATION_NOTES.asc
+++ b/TRANSLATION_NOTES.asc
@@ -49,7 +49,7 @@ bare repo => [裸仓库]
 
 bisect => [二分查找]
 
-blob => (保留原文不翻译)
+blob object => [元对象]
 
 branch => [分支]
 
@@ -76,6 +76,8 @@ code review => [代码审查]
 command => [命令]
 
 commit => [提交/提交记录]
+
+commit object => [提交对象]
 
 confilict => [冲突]
 
@@ -195,9 +197,15 @@ submodule => [子模块]
 
 tag => [标签/打标签]
 
+tag object => [标签对象]
+
 three-way merge => [三方合并]
 
 track => [跟踪]
+
+tree => [目录树]
+
+tree object => [目录树对象]
 
 ==== *U*
 

--- a/TRANSLATION_NOTES.asc
+++ b/TRANSLATION_NOTES.asc
@@ -49,7 +49,7 @@ bare repo => [裸仓库]
 
 bisect => [二分查找]
 
-blob object => [元对象]
+blob object => [数据对象]
 
 branch => [分支]
 
@@ -203,9 +203,9 @@ three-way merge => [三方合并]
 
 track => [跟踪]
 
-tree => [目录树]
+tree => [树/目录树]
 
-tree object => [目录树对象]
+tree object => [树对象]
 
 ==== *U*
 


### PR DESCRIPTION
请参阅 #130 的讨论。

  - 出于统一形式的考虑，提议“blob object”翻译为“元对象”。

  - 新增条目如下：

      * “commit object” => “提交对象”
      * “tag object” => “标签对象”
      * “tree object” => “目录树对象”
      * “tree” => “目录树”