### PR TITLE
Translate 10-git-internals refspec (Originally #74 )

### DIFF
--- a/book/10-git-internals/sections/refspec.asc
+++ b/book/10-git-internals/sections/refspec.asc
@@ -61,11 +61,11 @@ From git@github.com:schacon/simplegit
  * [new branch]      topic      -> origin/topic
 ----
 
-在这个例子中，对 master 分支的拉取操作被拒绝，因为它不是一个可以快进的引用。
+在这个例子中，对 `master` 分支的拉取操作被拒绝，因为它不是一个可以快进的引用。
 我们可以通过在引用规格之前指定 `+` 号来覆盖该规则。
 
 你也可以在配置文件中指定多个用于获取操作的引用规格。
-如果想在每次获取时都包括 master 和 experiment 分支，添加如下两行：
+如果想在每次获取时都包括 `master` 和 `experiment` 分支，添加如下两行：
 
 [source,ini]
 ----
@@ -83,7 +83,7 @@ fetch = +refs/heads/qa*:refs/remotes/origin/qa*
 ----
 
 但我们可以使用命名空间（或目录）来达到类似目的。
-假设你有一个 QA 团队，他们推送了一系列分支，同时你只想要获取 master 和 QA 团队的所有分支而不关心其他任何分支，那么可以使用如下配置：
+假设你有一个 QA 团队，他们推送了一系列分支，同时你只想要获取 `master` 和 QA 团队的所有分支而不关心其他任何分支，那么可以使用如下配置：
 
 [source,ini]
 ----
@@ -129,4 +129,4 @@ $ git push origin master:refs/heads/qa/master
 $ git push origin :topic
 ----
 
-因为引用规格（的格式）是 `<src>:<dst>`，所以上述命令把 `<src>` 留空，意味着把远程版本库的 topic 分支定义为空值，也就是删除它。
+因为引用规格（的格式）是 `<src>:<dst>`，所以上述命令把 `<src>` 留空，意味着把远程版本库的 `topic` 分支定义为空值，也就是删除它。

--- a/book/10-git-internals/sections/refspec.asc
+++ b/book/10-git-internals/sections/refspec.asc
@@ -61,7 +61,7 @@ From git@github.com:schacon/simplegit
  * [new branch]      topic      -> origin/topic
 ----
 
-在这个例子中，`master` 分支的拉取操作被拒绝，因为该分支不是一个可以快进的引用。
+在这个例子中，master 分支的拉取操作被拒绝，因为该分支不是一个可以快进的引用。
 我们可以通过在引用规格之前指定 `+` 号来覆盖该规则。
 
 你也可以在配置文件中指定多个用于获取操作的引用规格。
@@ -129,4 +129,4 @@ $ git push origin master:refs/heads/qa/master
 $ git push origin :topic
 ----
 
-因为引用规格（的格式）是 `<src>:<dst>`，所以上述命令把 `<src>` 留空，意味着把远程版本库的 `topic` 分支定义为空值，也就是删除它。
+因为引用规格（的格式）是 `<src>:<dst>`，所以上述命令把 `<src>` 留空，意味着把远程版本库的 topic 分支定义为空值，也就是删除它。

--- a/book/10-git-internals/sections/refspec.asc
+++ b/book/10-git-internals/sections/refspec.asc
@@ -75,7 +75,7 @@ From git@github.com:schacon/simplegit
 	fetch = +refs/heads/experiment:refs/remotes/origin/experiment
 ----
 
-我们不能在模式 `src` 中使用通配符，所以像下面这样的引用规格是不合法的：
+我们不能在模式中使用部分通配符，所以像下面这样的引用规格是不合法的：
 
 [source]
 ----

--- a/book/10-git-internals/sections/refspec.asc
+++ b/book/10-git-internals/sections/refspec.asc
@@ -61,7 +61,7 @@ From git@github.com:schacon/simplegit
  * [new branch]      topic      -> origin/topic
 ----
 
-在这个例子中，master 分支的拉取操作被拒绝，因为该分支不是一个可以快进的引用。
+在这个例子中，对 master 分支的拉取操作被拒绝，因为它不是一个可以快进的引用。
 我们可以通过在引用规格之前指定 `+` 号来覆盖该规则。
 
 你也可以在配置文件中指定多个用于获取操作的引用规格。

--- a/book/10-git-internals/sections/refspec.asc
+++ b/book/10-git-internals/sections/refspec.asc
@@ -1,15 +1,15 @@
 [[_refspec]]
-=== The Refspec
+=== 引用表达式（Refspec）
 
-Throughout this book, we've used simple mappings from remote branches to local references, but they can be more complex.
-Suppose you add a remote like this:
+纵观全书，我们已经使用过一些诸如远程分支到本地引用的简单映射方式，但是还有更复杂的。
+假设你添加了这样一个远程版本库：
 
 [source,console]
 ----
 $ git remote add origin https://github.com/schacon/simplegit-progit
 ----
 
-It adds a section to your `.git/config` file, specifying the name of the remote (`origin`), the URL of the remote repository, and the refspec for fetching:
+上面的命令将在你的 `.git/config` 文件中添加一个小节，指定了远程版本库的名称（`origin`）、URL 地址、以及用于获取的引用表达式（Refspec）：
 
 [source,ini]
 ----
@@ -18,11 +18,9 @@ It adds a section to your `.git/config` file, specifying the name of the remote 
 	fetch = +refs/heads/*:refs/remotes/origin/*
 ----
 
-The format of the refspec is an optional `+`, followed by `<src>:<dst>`, where `<src>` is the pattern for references on the remote side and `<dst>` is where those references will be written locally.
-The `+` tells Git to update the reference even if it isn't a fast-forward.
+引用表达式的格式是由一个可选的 `+` 号和 `<src>:<dst>` 组成，这里 `<src>` 是远程上的引用格式， `<dst>` 是将要记录在本地的引用格式。可选的 `+` 号告诉 Git 即使不能快速演进，也要强制更新引用格式。
 
-In the default case that is automatically written by a `git remote add` command, Git fetches all the references under `refs/heads/` on the server and writes them to `refs/remotes/origin/` locally.
-So, if there is a `master` branch on the server, you can access the log of that branch locally via
+默认情况下引用表达式由 `git remote add` 命令自动生成， Git 获取服务器中 `refs/heads/` 下面的所有引用，并将它写入到本地的 `refs/remotes/origin/` 中。 所以，如果服务器上有一个 `master` 分支，即可在本地通过下面这种方式来访问分支记录：
 
 [source,console]
 ----
@@ -31,26 +29,23 @@ $ git log remotes/origin/master
 $ git log refs/remotes/origin/master
 ----
 
-They're all equivalent, because Git expands each of them to `refs/remotes/origin/master`.
+上面的三个命令作用相同，因为 Git 把它们都扩展成 `refs/remotes/origin/master`。
 
-If you want Git instead to pull down only the `master` branch each time, and not every other branch on the remote server, you can change the fetch line to
+如果想让 Git 每次只拉取远程的 `master` 分支，而不是所有分支，可以把 fetch 行修改为：
 
 [source]
 ----
 fetch = +refs/heads/master:refs/remotes/origin/master
 ----
 
-This is just the default refspec for `git fetch` for that remote.
-If you want to do something one time, you can specify the refspec on the command line, too.
-To pull the `master` branch on the remote down to `origin/mymaster` locally, you can run
+这只是针对远程的 `git fetch` 操作的默认引用表达式。如果只想执行一次该操作，可以在命令行指定引用表达式。将远程的 `master` 分支拉取到本地的 `origin/mymaster` 分支，可以运行：
 
 [source,console]
 ----
 $ git fetch origin master:refs/remotes/origin/mymaster
 ----
 
-You can also specify multiple refspecs.
-On the command line, you can pull down several branches like so:
+你也可以指定多个引用表达式。使用命令行，你可以按照如下的方式拉取多个分支：
 
 [source,console]
 ----
@@ -61,11 +56,9 @@ From git@github.com:schacon/simplegit
  * [new branch]      topic      -> origin/topic
 ----
 
-In this case, the  master branch pull was rejected because it wasn't a fast-forward reference.
-You can override that by specifying the `+` in front of the refspec.
+在这个例子中，`master` 分支的拉取操作被拒绝，因为该分支不是一个可以快速演进的引用。可以通过在引用表达式之前使用 `+` 号来强制更新。
 
-You can also specify multiple refspecs for fetching in your configuration file.
-If you want to always fetch the master and experiment branches, add two lines:
+你也可以在配置文件中指定多个引用表达式。如果想在每次获取时都包括 `master` 和 `experiment` 分支，添加如下两行：
 
 [source,ini]
 ----
@@ -75,15 +68,15 @@ If you want to always fetch the master and experiment branches, add two lines:
 	fetch = +refs/heads/experiment:refs/remotes/origin/experiment
 ----
 
-You can't use partial globs in the pattern, so this would be invalid:
+注意这里不能使用部分通配符，所以下面这样就是不合法的：
 
 [source]
 ----
 fetch = +refs/heads/qa*:refs/remotes/origin/qa*
 ----
 
-However, you can use namespaces (or directories) to accomplish something like that.
-If you have a QA team that pushes a series of branches, and you want to get the master branch and any of the QA team's branches but nothing else, you can use a config section like this:
+但可以使用命名空间（或目录）来达到这个目的。
+如果你有一个 QA 团队，推送了一系列分支，而你只要获取 master 和 QA 团队的这些分支，那么，你可以使用如下的配置：
 
 [source,ini]
 ----
@@ -93,22 +86,20 @@ If you have a QA team that pushes a series of branches, and you want to get the 
 	fetch = +refs/heads/qa/*:refs/remotes/origin/qa/*
 ----
 
-If you have a complex workflow process that has a QA team pushing branches, developers pushing branches, and integration teams pushing and collaborating on remote branches, you can namespace them easily this way.
+如果工作流很复杂，有 QA 团队推送的分支、开发人员推送的分支、还有集成团队推送并且在远程分支上协作，可以为他们创建各自的命名空间解决类似问题。
 
 [[_pushing_refspecs]]
-==== Pushing Refspecs
+==== 推送引用表达式
 
-It's nice that you can fetch namespaced references that way, but how does the QA team get their branches into a `qa/` namespace in the first place?
-You accomplish that by using refspecs to push.
-
-If the QA team wants to push their `master` branch to `qa/master` on the remote server, they can run
+采用命名空间的方式来获取分支是个好主意，但 QA 团队一开始如何将他们的分支推送到 `qa/` 命名空间呢？答案是通过引用表达式的推送来完成。
+如果 QA 团队想把他们的 `master` 分支推送到远程服务器的 `qa/master` 分支上，可以运行：
 
 [source,console]
 ----
 $ git push origin master:refs/heads/qa/master
 ----
 
-If they want Git to do that automatically each time they run `git push origin`, they can add a `push` value to their config file:
+如果他们希望 Git 每次运行 `git push origin` 时都如上这样推送，他们可以在配置文件中添加一个 `push` 值：
 
 [source,ini]
 ----
@@ -118,15 +109,15 @@ If they want Git to do that automatically each time they run `git push origin`, 
 	push = refs/heads/master:refs/heads/qa/master
 ----
 
-Again, this will cause a `git push origin` to push the local `master` branch to the remote `qa/master` branch by default.
+同样的，这会让 `git push origin` 默认把本地 `master` 分支推送到远程 `qa/master` 分支。
 
-==== Deleting References
+==== 删除引用
 
-You can also use the refspec to delete references from the remote server by running something like this:
+你也可以使用引用表达式来删除远程服务器的引用，运行如下命令：
 
 [source,console]
 ----
 $ git push origin :topic
 ----
 
-Because the refspec is `<src>:<dst>`, by leaving off the `<src>` part, this basically says to make the topic branch on the remote nothing, which deletes it.
+因为引用表达式的格式是 `<src>:<dst>`, 所以把 `<src>` 留空的意思就是把远程的 `topic` 分支定义为空值，也就是删除它。

--- a/book/10-git-internals/sections/refspec.asc
+++ b/book/10-git-internals/sections/refspec.asc
@@ -1,7 +1,7 @@
 [[_refspec]]
-=== 引用表达式（Refspec）
+=== 引用规格
 
-纵观全书，我们已经使用过一些诸如远程分支到本地引用的简单映射方式，但是还有更复杂的。
+纵观全书，我们已经使用过一些诸如远程分支到本地引用的简单映射方式，但这种映射可以更复杂。
 假设你添加了这样一个远程版本库：
 
 [source,console]
@@ -9,7 +9,7 @@
 $ git remote add origin https://github.com/schacon/simplegit-progit
 ----
 
-上面的命令将在你的 `.git/config` 文件中添加一个小节，指定了远程版本库的名称（`origin`）、URL 地址、以及用于获取的引用表达式（Refspec）：
+上述命令会在你的 `.git/config` 文件中添加一个小节，并在其中指定远程版本库的名称（`origin`）、URL 和一个用于获取操作的引用规格（refspec）：
 
 [source,ini]
 ----
@@ -18,11 +18,11 @@ $ git remote add origin https://github.com/schacon/simplegit-progit
 	fetch = +refs/heads/*:refs/remotes/origin/*
 ----
 
-引用表达式的格式是由一个可选的 `+` 号和 `<src>:<dst>` 组成，这里 `<src>` 是远程上的引用， `<dst>` 是将要记录在本地的引用。
-可选的 `+` 号告诉 Git 即使不能快速演进，也要强制更新引用。
+引用规格的格式由一个可选的 `+` 号和紧随其后的 `<src>:<dst>` 组成，其中 `<src>` 是一个模式（pattern），代表远程版本库中的引用；`<dst>` 是那些远程引用在本地所对应的位置。
+`+` 号告诉 Git 即使在不能快进的情况下也要（强制）更新引用。
 
-默认情况下引用表达式由 `git remote add` 命令自动生成， Git 获取服务器中 `refs/heads/` 下面的所有引用，并将它写入到本地的 `refs/remotes/origin/` 中。
-所以，如果服务器上有一个 `master` 分支，即可在本地通过下面这种方式来访问分支记录：
+默认情况下，引用规格由 `git remote add` 命令自动生成， Git 获取服务器中 `refs/heads/` 下面的所有引用，并将它写入到本地的 `refs/remotes/origin/` 中。
+所以，如果服务器上有一个 `master` 分支，我们可以在本地通过下面这种方式来访问该分支上的提交记录：
 
 [source,console]
 ----
@@ -31,26 +31,26 @@ $ git log remotes/origin/master
 $ git log refs/remotes/origin/master
 ----
 
-上面的三个命令作用相同，因为 Git 把它们都扩展成 `refs/remotes/origin/master`。
+上面的三个命令作用相同，因为 Git 会把它们都扩展成 `refs/remotes/origin/master`。
 
-如果想让 Git 每次只拉取远程的 `master` 分支，而不是所有分支，可以把 fetch 行修改为：
+如果想让 Git 每次只拉取远程的 `master` 分支，而不是所有分支，可以把（引用规格的）获取那一行修改为：
 
 [source]
 ----
 fetch = +refs/heads/master:refs/remotes/origin/master
 ----
 
-这只是针对远程的 `git fetch` 操作的默认引用表达式。
-如果只想执行一次该操作，可以在命令行指定引用表达式。
-将远程的 `master` 分支拉取到本地的 `origin/mymaster` 分支，可以运行：
+这仅是针对该远程版本库的 `git fetch` 操作的默认引用规格。
+如果有某些只希望被执行一次的特定获取操作，我们也可以在命令行指定引用规格。
+若要将远程的 `master` 分支拉到本地的 `origin/mymaster` 分支，可以运行：
 
 [source,console]
 ----
 $ git fetch origin master:refs/remotes/origin/mymaster
 ----
 
-你也可以指定多个引用表达式。
-使用命令行，你可以按照如下的方式拉取多个分支：
+你也可以指定多个引用规格。
+在命令行中，你可以按照如下的方式拉取多个分支：
 
 [source,console]
 ----
@@ -61,11 +61,11 @@ From git@github.com:schacon/simplegit
  * [new branch]      topic      -> origin/topic
 ----
 
-在这个例子中，`master` 分支的拉取操作被拒绝，因为该分支不是一个可以快速演进的引用。
-可以通过在引用表达式之前使用 `+` 号来强制更新。
+在这个例子中，`master` 分支的拉取操作被拒绝，因为该分支不是一个可以快进的引用。
+我们可以通过在引用规格之前指定 `+` 号来覆盖该规则。
 
-你也可以在配置文件中指定多个引用表达式。
-如果想在每次获取时都包括 `master` 和 `experiment` 分支，添加如下两行：
+你也可以在配置文件中指定多个用于获取操作的引用规格。
+如果想在每次获取时都包括 master 和 experiment 分支，添加如下两行：
 
 [source,ini]
 ----
@@ -75,15 +75,15 @@ From git@github.com:schacon/simplegit
 	fetch = +refs/heads/experiment:refs/remotes/origin/experiment
 ----
 
-注意这里不能使用部分通配符，所以下面这样就是不合法的：
+我们不能在模式 `src` 中使用通配符，所以像下面这样的引用规格是不合法的：
 
 [source]
 ----
 fetch = +refs/heads/qa*:refs/remotes/origin/qa*
 ----
 
-但可以使用命名空间（或目录）来达到这个目的。
-如果你有一个 QA 团队，推送了一系列分支，而你只要获取 master 和 QA 团队的这些分支，那么，你可以使用如下的配置：
+但我们可以使用命名空间（或目录）来达到类似目的。
+假设你有一个 QA 团队，他们推送了一系列分支，同时你只想要获取 master 和 QA 团队的所有分支而不关心其他任何分支，那么可以使用如下配置：
 
 [source,ini]
 ----
@@ -93,13 +93,13 @@ fetch = +refs/heads/qa*:refs/remotes/origin/qa*
 	fetch = +refs/heads/qa/*:refs/remotes/origin/qa/*
 ----
 
-如果工作流很复杂，有 QA 团队推送的分支、开发人员推送的分支、还有集成团队推送并且在远程分支上协作，可以为他们创建各自的命名空间解决类似问题。
+如果项目的工作流很复杂，有 QA 团队推送分支、开发人员推送分支、集成团队推送并且在远程分支上展开协作，你就可以像这样（在本地）为这些分支创建各自的命名空间，非常方便。
 
 [[_pushing_refspecs]]
-==== 推送引用表达式
+==== 引用规格推送
 
-采用命名空间的方式来获取分支是个好主意，但 QA 团队一开始如何将他们的分支推送到 `qa/` 命名空间呢？
-答案是通过引用表达式的推送来完成。
+像上面这样从远程版本库获取已在命名空间中的引用当然很棒，但 QA 团队最初应该如何将他们的分支放入远程的 `qa/` 命名空间呢？
+我们可以通过引用规格推送来完成这个任务。
 
 如果 QA 团队想把他们的 `master` 分支推送到远程服务器的 `qa/master` 分支上，可以运行：
 
@@ -108,7 +108,7 @@ fetch = +refs/heads/qa*:refs/remotes/origin/qa*
 $ git push origin master:refs/heads/qa/master
 ----
 
-如果他们希望 Git 每次运行 `git push origin` 时都如上这样推送，他们可以在配置文件中添加一个 `push` 值：
+如果他们希望 Git 每次运行 `git push origin` 时都像上面这样推送，可以在他们的配置文件中添加一条 `push` 值：
 
 [source,ini]
 ----
@@ -118,15 +118,15 @@ $ git push origin master:refs/heads/qa/master
 	push = refs/heads/master:refs/heads/qa/master
 ----
 
-同样的，这会让 `git push origin` 默认把本地 `master` 分支推送到远程 `qa/master` 分支。
+正如刚才所指出的，这会让 `git push origin` 默认把本地 `master` 分支推送到远程 `qa/master` 分支。
 
 ==== 删除引用
 
-你也可以使用引用表达式来删除远程服务器的引用，运行如下命令：
+你还可以借助类似下面的命令通过引用规格从远程服务器上删除引用：
 
 [source,console]
 ----
 $ git push origin :topic
 ----
 
-因为引用表达式的格式是 `<src>:<dst>`, 所以把 `<src>` 留空的意思就是把远程的 `topic` 分支定义为空值，也就是删除它。
+因为引用规格（的格式）是 `<src>:<dst>`，所以上述命令把 `<src>` 留空，意味着把远程版本库的 `topic` 分支定义为空值，也就是删除它。

--- a/book/10-git-internals/sections/refspec.asc
+++ b/book/10-git-internals/sections/refspec.asc
@@ -41,7 +41,7 @@ fetch = +refs/heads/master:refs/remotes/origin/master
 ----
 
 这仅是针对该远程版本库的 `git fetch` 操作的默认引用规格。
-如果有某些只希望被执行一次的特定获取操作，我们也可以在命令行指定引用规格。
+如果有某些只希望被执行一次的操作，我们也可以在命令行指定引用规格。
 若要将远程的 `master` 分支拉到本地的 `origin/mymaster` 分支，可以运行：
 
 [source,console]

--- a/book/10-git-internals/sections/refspec.asc
+++ b/book/10-git-internals/sections/refspec.asc
@@ -18,9 +18,11 @@ $ git remote add origin https://github.com/schacon/simplegit-progit
 	fetch = +refs/heads/*:refs/remotes/origin/*
 ----
 
-引用表达式的格式是由一个可选的 `+` 号和 `<src>:<dst>` 组成，这里 `<src>` 是远程上的引用格式， `<dst>` 是将要记录在本地的引用格式。可选的 `+` 号告诉 Git 即使不能快速演进，也要强制更新引用格式。
+引用表达式的格式是由一个可选的 `+` 号和 `<src>:<dst>` 组成，这里 `<src>` 是远程上的引用， `<dst>` 是将要记录在本地的引用。
+可选的 `+` 号告诉 Git 即使不能快速演进，也要强制更新引用。
 
-默认情况下引用表达式由 `git remote add` 命令自动生成， Git 获取服务器中 `refs/heads/` 下面的所有引用，并将它写入到本地的 `refs/remotes/origin/` 中。 所以，如果服务器上有一个 `master` 分支，即可在本地通过下面这种方式来访问分支记录：
+默认情况下引用表达式由 `git remote add` 命令自动生成， Git 获取服务器中 `refs/heads/` 下面的所有引用，并将它写入到本地的 `refs/remotes/origin/` 中。
+所以，如果服务器上有一个 `master` 分支，即可在本地通过下面这种方式来访问分支记录：
 
 [source,console]
 ----
@@ -38,14 +40,17 @@ $ git log refs/remotes/origin/master
 fetch = +refs/heads/master:refs/remotes/origin/master
 ----
 
-这只是针对远程的 `git fetch` 操作的默认引用表达式。如果只想执行一次该操作，可以在命令行指定引用表达式。将远程的 `master` 分支拉取到本地的 `origin/mymaster` 分支，可以运行：
+这只是针对远程的 `git fetch` 操作的默认引用表达式。
+如果只想执行一次该操作，可以在命令行指定引用表达式。
+将远程的 `master` 分支拉取到本地的 `origin/mymaster` 分支，可以运行：
 
 [source,console]
 ----
 $ git fetch origin master:refs/remotes/origin/mymaster
 ----
 
-你也可以指定多个引用表达式。使用命令行，你可以按照如下的方式拉取多个分支：
+你也可以指定多个引用表达式。
+使用命令行，你可以按照如下的方式拉取多个分支：
 
 [source,console]
 ----
@@ -56,9 +61,11 @@ From git@github.com:schacon/simplegit
  * [new branch]      topic      -> origin/topic
 ----
 
-在这个例子中，`master` 分支的拉取操作被拒绝，因为该分支不是一个可以快速演进的引用。可以通过在引用表达式之前使用 `+` 号来强制更新。
+在这个例子中，`master` 分支的拉取操作被拒绝，因为该分支不是一个可以快速演进的引用。
+可以通过在引用表达式之前使用 `+` 号来强制更新。
 
-你也可以在配置文件中指定多个引用表达式。如果想在每次获取时都包括 `master` 和 `experiment` 分支，添加如下两行：
+你也可以在配置文件中指定多个引用表达式。
+如果想在每次获取时都包括 `master` 和 `experiment` 分支，添加如下两行：
 
 [source,ini]
 ----
@@ -91,7 +98,9 @@ fetch = +refs/heads/qa*:refs/remotes/origin/qa*
 [[_pushing_refspecs]]
 ==== 推送引用表达式
 
-采用命名空间的方式来获取分支是个好主意，但 QA 团队一开始如何将他们的分支推送到 `qa/` 命名空间呢？答案是通过引用表达式的推送来完成。
+采用命名空间的方式来获取分支是个好主意，但 QA 团队一开始如何将他们的分支推送到 `qa/` 命名空间呢？
+答案是通过引用表达式的推送来完成。
+
 如果 QA 团队想把他们的 `master` 分支推送到远程服务器的 `qa/master` 分支上，可以运行：
 
 [source,console]

--- a/status.json
+++ b/status.json
@@ -104,7 +104,7 @@
       "sections/packfiles.asc": 0,
       "sections/plumbing-porcelain.asc": 100,
       "sections/refs.asc": 100,
-      "sections/refspec.asc": 0,
+      "sections/refspec.asc": 100,
       "sections/transfer-protocols.asc": 0
     },
     "A-git-in-other-environments": {


### PR DESCRIPTION
Squashed commit of the following (originally token from #74 ):

commit 579ae77d4cc7325519fa712bd9f465c898738fef
Author: morstar <chenxing_cn@hotmail.com>
Date:   Sat Jun 13 10:23:10 2015 +0800

    rebase conflicted file

commit d68a60079039ada75b1b707189a0a4704034a7ac
Author: morstar <chenxing_cn@hotmail.com>
Date:   Sat Jun 13 10:18:27 2015 +0800

    rebase 10-git-internals/1-git-internals

commit 1d4a83e9c6ffe78cadd0eb9ada09dd5d645a5abc
Author: morstar <chenxing_cn@hotmail.com>
Date:   Sat Jun 13 10:01:01 2015 +0800

    rebase conflicted file

commit a3d6fa1c61c297f47920302bb5d5878c6b82d252
Author: morstar <chenxing_cn@hotmail.com>
Date:   Sat Jun 13 09:53:01 2015 +0800

    unify the vocabulary and del useless space

    将 origin 统一译为“远程版本库”，删除多余空白

commit 2155728e6a37907365a4bb2ee5842bf2dc432e73
Author: morstar <chenxing_cn@hotmail.com>
Date:   Wed Jun 10 02:38:25 2015 +0800

    Update 10-git-internals/1-git-internals.asc

    Simplify some sentences and clarify the logic.

commit 0b85182b706cb716b773ce6c3b45cd30924c6a69
Author: morstar <chenxing_cn@hotmail.com>
Date:   Wed Jun 10 02:18:30 2015 +0800

    Update 1-git-internals.asc

commit e35d6055ebfd45f27259da5de347d8c3d9bb2bce
Author: morstar <chenxing_cn@hotmail.com>
Date:   Wed Jun 10 02:16:38 2015 +0800

    Update TRANSLATION_NOTES.asc

commit 472980615352bf454c530e3d42197018500430b3
Author: morstar <chenxing_cn@hotmail.com>
Date:   Wed Jun 10 02:06:42 2015 +0800

    Translated 10-git-internals/sections/refspec

commit 964c21c73b7fbac4f206f308c6594929d795c7a2
Author: morstar <chenxing_cn@hotmail.com>
Date:   Wed Jun 10 00:45:32 2015 +0800

    update 'reference' & 'refspec'

    reference to the Chinese translations for Git package

commit 9d68c37cedb77f74970013f16c53be215a8131c1
Author: morstar <chenxing_cn@hotmail.com>
Date:   Tue Jun 9 22:31:57 2015 +0800

    some minor adjustments