### PR TITLE
Escaping quotation marks within an attribute block

### DIFF
--- a/book/A-git-in-other-environments/sections/visualstudio.asc
+++ b/book/A-git-in-other-environments/sections/visualstudio.asc
@@ -18,7 +18,7 @@ Visual Studio 能够记住所有你打开过的用 Git 管理的项目，它们�
 
 [[vs_home]]
 .Visual Studio 中的 Git 仓库的 "Home" 视图。
-image::images/vs-2.png[Visual Studio 中的 Git 仓库的 "Home" 视图。]
+image::images/vs-2.png[Visual Studio 中的 Git 仓库的 &quot;Home&quot; 视图。]
 
 Visual Studio 现在拥有一套着眼于任务的强大 Git 操作界面。
 它包括线性的历史视图、diff 视图、远程仓库操作命令，以及其它很多功能。


### PR DESCRIPTION
Hi @networm,

I've escaped the quotation marks in the attribute block for this `image::` markup:

````
image::images/vs-2.png[Visual Studio 中的 Git 仓库的 "Home" 视图。]
````

Which should correct the build error for the book.

Hope this helps,
Sanders