### PR TITLE
Update Git Glossary

### DIFF
--- a/TRANSLATION_NOTES.asc
+++ b/TRANSLATION_NOTES.asc
@@ -50,7 +50,7 @@ apply => 应用
 
 argument => 参数
 
-authentication => 授权
+authentication => 认证
 
 ==== *B*
 

--- a/TRANSLATION_NOTES.asc
+++ b/TRANSLATION_NOTES.asc
@@ -26,15 +26,19 @@
 
 术语的译法应当优先参考“link:https://github.com/git/git/blob/master/po/zh_CN.po[Git 软件包的简体中文翻译]”。
 
+==== *#*
+
+3-way merge => 三方合并
+
 ==== *A*
 
-abbreviate => 摘要
+abbreviate => 简写/简写的 SHA-1 值
 
 abbreviated => 简写的
 
 amend => 修补
 
-ancestor => 祖先
+ancestor => 祖先/祖先提交
 
 annotate => 附注
 
@@ -42,7 +46,7 @@ annotated => 附注的
 
 annotated tag => 附注标签
 
-apply => 应用/apply
+apply => 应用
 
 argument => 参数
 
@@ -50,7 +54,11 @@ authentication => 授权
 
 ==== *B*
 
-bare repo => 裸仓库
+backport => 向后移植
+
+bare repo => 纯仓库
+
+bare repository => 纯仓库
 
 binding => 绑定
 
@@ -68,11 +76,13 @@ certificate => 证书
 
 checkout => 检出
 
-checksum => 校验和
+checksum => 校验/校验和
 
 cherry-pick => 拣选
 
 chunk => 块/区块
+
+clean => 干净/干净的工作区
 
 client => 客户端
 
@@ -80,9 +90,11 @@ clone => 克隆
 
 code review => 代码审查
 
+collaborator => 合作者
+
 command => 命令
 
-commit => 提交/提交记录
+commit => 提交
 
 commit message => 提交信息
 
@@ -90,13 +102,17 @@ commit object => 提交对象
 
 confilict => 冲突
 
-contributing => 贡献
+contributing => 贡献/作贡献
+
+contribution => 贡献
+
+contributor => 贡献者
 
 ==== *D*
 
 dangling object => 摇摆对象
 
-dumb => 哑
+dumb HTTP protocol => 哑 HTTP 协议
 
 ==== *E*
 
@@ -108,7 +124,7 @@ endpoint => 接口
 
 fast-forward => 快进
 
-fetch => 抓取
+fetch => 获取
 
 fork => 派生
 
@@ -118,7 +134,15 @@ guideline => 准则
 
 ==== *H*
 
-HEAD => HEAD
+hash => 哈希/哈希值
+
+HEAD => HEAD/头指针/当前分支
+
+head => 头/分支
+
+header => 头信息
+
+hook => 钩子
 
 hunk => 数据块/区块/片段
 
@@ -127,6 +151,8 @@ hunk => 数据块/区块/片段
 ignore => 忽略
 
 importer => 导入器
+
+index => index/索引/暂存区
 
 issue => 缺陷/问题/议题/issue
 
@@ -150,6 +176,14 @@ merge => 合并
 
 ==== *O*
 
+object => 对象
+
+object database => 对象库
+
+object name => 对象名称
+
+object type => 对象类型
+
 option => 选项
 
 ==== *P*
@@ -166,17 +200,21 @@ parent => 父提交
 
 patch => 补丁
 
-plumbing => 底层命令
+pathspec => 路径规格
 
-porcelain => 高层命令
+pattern => 模式
+
+plumbing => 管件
+
+porcelain => 瓷件
 
 progressive-stability => 渐进稳定
 
-pull => 拉取/pull
+pull => 拉/拉取
 
-pull request => 合并请求
+pull request => 拉取请求
 
-push => 推送
+push => 推/推送
 
 ==== *Q*
 
@@ -186,27 +224,47 @@ reapply => 重新应用
 
 rebase => 变基
 
+ref => 引用
+
+reference => 引用
+
+reflog => 引用日志
+
+refspec => 引用规格
+
 regex => 正则表达式
 
 remote => 远程/远程仓库
 
-remote help => 远程助手
+remote helper => 远程助手
 
-replay => 重演
+remote-tracking branch => 远程跟踪分支
 
-repo => 仓库/repo
+replay => 重放
+
+repo => 仓库
 
 repository => 仓库
 
-reverse => 还原
+resolve => 解决
 
-revert => 恢复/反转
+reverse => 反转/相反
 
-revision => 修订版本
+revert => 还原
+
+revision => 版本
+
+rewind => 回退
 
 rewrite => 重写
 
 ==== *S*
+
+SCM => SCM/源代码管理工具
+
+SHA-1 => SHA-1
+
+shorthand => 简写
 
 show => 显示
 
@@ -214,31 +272,33 @@ sign => 签名
 
 signed => 已签署的/已签名的
 
+signed tag => 签名标签
+
 silo => 流水线
 
-shorthand => 简写
+smart HTTP protocol => 智能
 
-smart => 智能
+squash => 压缩
 
-squash => 压缩/挤进
+stage => 暂存
 
-stage => 暂存/缓存
+staged => 已暂存的
 
-staged => 已暂存的/已缓存的
+staging area => 暂存区
 
-staging area => 暂存区/缓存区
-
-stash => 保存进度
+stash => 进度保存/保存进度
 
 store => 保存/存储
 
-submodule => 子模块
+submodule => 子模组
 
 ==== *T*
 
 tag => 标签/打标签
 
 tag object => 标签对象
+
+tagger => 打标签者
 
 three-way merge => 三方合并
 
@@ -256,9 +316,11 @@ tree object => 树对象
 
 unambiguous => 没有歧义/没有歧义的
 
-unannotated => 不含注解的
+unannotated tag => 未附注标签
 
 unpack => 解包
+
+unstage => 取消暂存
 
 upstream => 上游/上游仓库
 

--- a/TRANSLATION_NOTES.asc
+++ b/TRANSLATION_NOTES.asc
@@ -94,6 +94,8 @@ contributing => [贡献]
 
 ==== *D*
 
+dangling object => [摇摆对象]
+
 dumb => [哑]
 
 ==== *E*

--- a/TRANSLATION_NOTES.asc
+++ b/TRANSLATION_NOTES.asc
@@ -28,107 +28,107 @@
 
 ==== *A*
 
-abbreviate => [摘要]
+abbreviate => 摘要
 
-abbreviated => [简写的]
+abbreviated => 简写的
 
-amend => [修补]
+amend => 修补
 
-ancestor => [祖先]
+ancestor => 祖先
 
-annotate => [附注]
+annotate => 附注
 
-annotated =>  [附注的]
+annotated => 附注的
 
-annotated tag => [附注标签]
+annotated tag => 附注标签
 
-apply => [应用] (或者根据上下文也可以选择不翻译)
+apply => 应用/apply
 
-argument => [参数]
+argument => 参数
 
-authentication => [授权]
+authentication => 授权
 
 ==== *B*
 
-bare repo => [裸仓库]
+bare repo => 裸仓库
 
-binding => [绑定]
+binding => 绑定
 
-bisect => [二分查找]
+bisect => 二分查找
 
-blob object => [数据对象]
+blob object => 数据对象
 
-branch => [分支]
+branch => 分支
 
-bug => (保留原文不翻译)
+bug => bug
 
 ==== *C*
 
-certificate => [证书]
+certificate => 证书
 
-checkout => [检出](或者根据上下文也可以选择不翻译)
+checkout => 检出
 
-checksum => [校验和]
+checksum => 校验和
 
-cherry-pick => [拣选]
+cherry-pick => 拣选
 
-chunk => [块/区块]
+chunk => 块/区块
 
-client => [客户端]
+client => 客户端
 
-clone => [克隆]
+clone => 克隆
 
-code review => [代码审查]
+code review => 代码审查
 
-command => [命令]
+command => 命令
 
-commit => [提交/提交记录]
+commit => 提交/提交记录
 
-commit message => [提交信息]
+commit message => 提交信息
 
-commit object => [提交对象]
+commit object => 提交对象
 
-confilict => [冲突]
+confilict => 冲突
 
-contributing => [贡献]
+contributing => 贡献
 
 ==== *D*
 
-dangling object => [摇摆对象]
+dangling object => 摇摆对象
 
-dumb => [哑]
+dumb => 哑
 
 ==== *E*
 
-email address => [邮件地址]
+email address => 邮件地址
 
-endpoint => [接口]
+endpoint => 接口
 
 ==== *F*
 
-fast-forward => [快进]
+fast-forward => 快进
 
-fetch => [抓取]
+fetch => 抓取
 
-fork => [派生] (或根据上下文保留原文不翻译)
+fork => 派生
 
 ==== *G*
 
-guideline => [准则]
+guideline => 准则
 
 ==== *H*
 
-HEAD => (保留原文不翻译)
+HEAD => HEAD
 
-hunk => [数据块/区块/片段]
+hunk => 数据块/区块/片段
 
 ==== *I*
 
-ignore => [忽略]
+ignore => 忽略
 
-importer => [导入器]
+importer => 导入器
 
-issue => [缺陷/问题/议题] (根据上下文选择合适词语，也可以保留原文不翻译)
+issue => 缺陷/问题/议题/issue
 
 ==== *J*
 
@@ -136,145 +136,145 @@ issue => [缺陷/问题/议题] (根据上下文选择合适词语，也可以�
 
 ==== *L*
 
-lightweight tag => [轻量标签]
+lightweight tag => 轻量标签
 
-log => [日志]
+log => 日志
 
-loose object => [松散对象]
+loose object => 松散对象
 
 ==== *M*
 
-merge => [合并]
+merge => 合并
 
 ==== *N*
 
 ==== *O*
 
-option => [选项]
+option => 选项
 
 ==== *P*
 
-pack => [打包/包]
+pack => 包/打包
 
-packed => [已经打包的]
+packed => 已打包的
 
-packfile => [包文件]
+packfile => 包文件
 
-parameter => [参数]
+parameter => 参数
 
-parent => [父提交]  `第一版中译者似乎把 parent ancestor 全部翻译成祖先`
+parent => 父提交
 
-patch => [补丁]
+patch => 补丁
 
-plumbing => [底层命令]
+plumbing => 底层命令
 
-porcelain => [高层命令]
+porcelain => 高层命令
 
-progressive-stability => [渐进稳定]
+progressive-stability => 渐进稳定
 
-pull => [拉取] (或者根据上下文不翻译)
+pull => 拉取/pull
 
-pull request => [合并请求]
+pull request => 合并请求
 
-push => [推送]
+push => 推送
 
 ==== *Q*
 
 ==== *R*
 
-reapply => [重新应用]
+reapply => 重新应用
 
-rebase => [变基]
+rebase => 变基
 
-regex => [正则表达式]
+regex => 正则表达式
 
-remote => [远程/远程仓库]
+remote => 远程/远程仓库
 
-remote help => [远程助手]
+remote help => 远程助手
 
-replay => [重演]
+replay => 重演
 
-repo => [仓库] (或者保留原文不翻译)
+repo => 仓库/repo
 
-repository => [仓库]
+repository => 仓库
 
-reverse => [还原]
+reverse => 还原
 
-revert => [恢复] `可以根据上下文决定翻译成 [恢复] 还是 [反转]`
+revert => 恢复/反转
 
-revision => [修订版本]
+revision => 修订版本
 
-rewrite => [重写]
+rewrite => 重写
 
 ==== *S*
 
-show => [显示]
+show => 显示
 
-sign => [签名]
+sign => 签名
 
-signed => [已经签署/签名的]
+signed => 已签署的/已签名的
 
-silo => [流水线]
+silo => 流水线
 
-shorthand => [简写]
+shorthand => 简写
 
-smart => [智能]
+smart => 智能
 
-squash => [压缩/挤进]  `第一版这个词没有很好的翻译出来`
+squash => 压缩/挤进
 
-stage => [暂存/缓存]
+stage => 暂存/缓存
 
-staged => [暂存的/缓存的]
+staged => 已暂存的/已缓存的
 
-staging area => [暂存区/缓存区]
+staging area => 暂存区/缓存区
 
-stash => [保存进度] (或者根据上下文选择相近含义的词)
+stash => 保存进度
 
-store => [保存/存储]
+store => 保存/存储
 
-submodule => [子模块]
+submodule => 子模块
 
 ==== *T*
 
-tag => [标签/打标签]
+tag => 标签/打标签
 
-tag object => [标签对象]
+tag object => 标签对象
 
-three-way merge => [三方合并]
+three-way merge => 三方合并
 
-track => [跟踪]
+track => 跟踪
 
-tracking branch => [跟踪分支]
+tracking branch => 跟踪分支
 
-topic branch => [特性分支]
+topic branch => 特性分支
 
-tree => [树/目录树]
+tree => 树/目录树
 
-tree object => [树对象]
+tree object => 树对象
 
 ==== *U*
 
-unambiguous => [没有歧义/没有歧义的]
+unambiguous => 没有歧义/没有歧义的
 
-unannotated => [不含注解的]
+unannotated => 不含注解的
 
-unpack => [解包]
+unpack => 解包
 
-upstream => [上游/上游仓库]
+upstream => 上游/上游仓库
 
 ==== *V*
 
-VCS => [版本控制系统] (或者根据上下文也可以选择不翻译)
+VCS => 版本控制系统/VCS
 
 ==== *W*
 
-whitespace => [多余的空白字符]
+whitespace => 多余的空白字符
 
-workflow => [工作流程]
+workflow => 工作流程
 
-working directory => [工作目录]
+working directory => 工作目录
 
-working tree => [工作区]
+working tree => 工作区
 
 ==== *X*
 

--- a/TRANSLATION_NOTES.asc
+++ b/TRANSLATION_NOTES.asc
@@ -290,7 +290,7 @@ stash => 进度保存/保存进度
 
 store => 保存/存储
 
-submodule => 子模组
+submodule => 子模块
 
 ==== *T*
 

--- a/TRANSLATION_NOTES.asc
+++ b/TRANSLATION_NOTES.asc
@@ -96,7 +96,7 @@ command => 命令
 
 commit => 提交
 
-commit message => 提交信息
+commit message => 提交说明
 
 commit object => 提交对象
 

--- a/TRANSLATION_NOTES.asc
+++ b/TRANSLATION_NOTES.asc
@@ -186,7 +186,7 @@ rebase => [变基]
 
 regex => [正则表达式]
 
-remote => [远程]
+remote => [远程/远程仓库]
 
 remote help => [远程助手]
 


### PR DESCRIPTION
1.    Format our git-glossary as following:
    
      - All entries are listed in alphabetical order.
    
      - For individual entries:
    
        `<original-word> => <translation>[/<choice-2>[/<choice-3>]...]`
    
        Where:
    
          * `<original-word>` stands for the term to be translated.
          * `<translation>` stands for the translated Chinese word for that
            term.
          * `<choice-2>`, `<choice-3>` stand for the second and third
            translation choices for that term.  If the `<original-word>`
            itself is in this list, then it means we can leave it
            *untranslated* during translation process.  We can certainly
            append this list as needed.

2. Update the git-glossary mainly according to the last version of https://github.com/git/git/blob/master/po/zh_CN.po and some other additional entries.
    
    This commit resolves issues listed as follow:
    
      - resolve #219 : index => index/索引/暂存区
      - resolve #224 : backport => 向后移植
      - resolve #234 : pull request => 拉取请求
      - resolve #240 : fork => 派生 (only one choice to avoid ambiguous)