### PR TITLE
Update 08-customizing-git attributes.asc

### DIFF
--- a/book/08-customizing-git/sections/attributes.asc
+++ b/book/08-customizing-git/sections/attributes.asc
@@ -280,7 +280,8 @@ test/ export-ignore
 
 ===== `export-subst`
 
-在导出文件进行部署的时候，你可以使用 `git log` 的格式化和关键字展开的处理，来选择被 `export-subst` 属性标记的部分文件。
+在导出文件进行部署的时候，你可以将 `git log` 的格式化和关键字展开处理应用于被
+`export-subst` 属性标记的部分文件。
 
 举个例子，如果你想在项目中包含一个叫做 `LAST_COMMIT` 的文件，并在运行 `git archive` 的时候自动向它注入最新提交的元数据，可以像这样设置该文件：
 
@@ -292,7 +293,6 @@ $ git add LAST_COMMIT .gitattributes
 $ git commit -am 'adding LAST_COMMIT file for archives'
 ----
 
-When you run `git archive`, the contents of the archived file will look like this:
 运行 `git archive` 之后，该文件被归档后的内容会被替换成这样：
 
 [source,console]
@@ -302,43 +302,26 @@ $ cat ../deployment-testing/LAST_COMMIT
 Last commit date: Tue Apr 21 08:38:48 2009 -0700 by Scott Chacon
 ----
 
-The substitutions can include for example the commit message and any git notes, and git log can do simple word wrapping:
-你也可以用诸如提交信息和其它 Git 记录进行替换，还可以应用 `git log` 风格的格式做简单的字词处理：
+你也可以用诸如提交信息或者任意的 git 注解进行替换，并且 git log 还能做简单的字词包装：
 
 [source.console]
 ----
 $ echo '$Format:Last commit: %h by %aN at %cd%n%+w(76,6,9)%B$' > LAST_COMMIT
-$ git commit -am 'export-subst uses git log's custom formatter
+$ git commit -am 'export-subst 使用 git log 的自定义格式化工具
 
-git archive uses git log's `pretty=format:` processor
-directly, and strips the surrounding `$Format:` and `$`
-markup from the output.
+git archive 直接使用 git log 的 `pretty=format:`
+处理器，并在输出中移除两侧的 `$Format:` 和 `$`
+标记。
 '
 $ git archive @ | tar xfO - LAST_COMMIT
 Last commit: 312ccc8 by Jim Hill at Fri May 8 09:14:04 2015 -0700
-       export-subst uses git log's custom formatter
+       export-subst 使用 git log 的自定义格式化工具
 
-         git archive uses git log's `pretty=format:` processor directly, and 
-         strips the surrounding `$Format:` and `$` markup from the output.
-----
-[source.console]
-----
-$ echo '$Format:Last commit: %h by %aN at %cd%n%+w(76,6,9)%B$' > LAST_COMMIT
-$ git commit -am 'export-subst uses git log's custom formatter
-
-git archive uses git log's `pretty=format:` processor
-directly, and strips the surrounding `$Format:` and `$`
-markup from the output.
-'
-$ git archive @ | tar xfO - LAST_COMMIT
-Last commit: 312ccc8 by Jim Hill at Fri May 8 09:14:04 2015 -0700
-       export-subst uses git log's custom formatter
-
-         git archive uses git log's `pretty=format:` processor directly, and 
-         strips the surrounding `$Format:` and `$` markup from the output.
+         git archive 直接使用 git log 的 `pretty=format:` 处理器，并 
+         在输出中移除两侧的 `$Format:` 和 `$` 标记。
 ----
 
-当前归档适用于当前的部署，但是不应该混用到以后的部署中。对 `export-subst` 的应用让我们可以避免这一点。
+由此得到的归档适用于（当前的）部署工作。然而和其他的导出归档一样，它并不适用于后继的部署工作。
 
 ==== 合并策略
 


### PR DESCRIPTION
- Remove extra original text.
- Sync the "export-subst" section with progit/progit2@6390e50 .
- Minor translation adjust in the "export-subst" section.

https://github.com/progit/progit2-zh/pull/132#issuecomment-131491604 中 @spacewander 提到会删除原文，但我发现最新的版本仍然没有做这个工作。同时我查看了 #255 ，也没有修复这个问题。

所以我创建这个 PR 来删除原文，并且和 progit/progit2@6390e50 保持同步（根据 #245 ）。