### PR TITLE
去掉 PDF 的多余空格，调整样式

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'awesome_print'
 
 gem 'asciidoctor-epub3', '1.0.0.alpha.2'
 gem 'asciidoctor-pdf', '1.5.0.alpha.8'
-gem 'asciidoctor-pdf-cjk-kai_gen_gothic', '~> 0.1.0'
+gem 'asciidoctor-pdf-cjk-kai_gen_gothic', '~> 0.1.1'
 
 gem 'coderay'
 gem 'pygments.rb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,13 +19,13 @@ GEM
       safe_yaml (= 1.0.4)
       thread_safe (= 0.3.4)
       treetop (= 1.5.3)
-    asciidoctor-pdf-cjk (0.1.1)
+    asciidoctor-pdf-cjk (0.1.2)
       asciidoctor-pdf (~> 1.5.0.alpha.8)
-    asciidoctor-pdf-cjk-kai_gen_gothic (0.1.0)
-      asciidoctor-pdf-cjk (~> 0.1.1)
+    asciidoctor-pdf-cjk-kai_gen_gothic (0.1.1)
+      asciidoctor-pdf-cjk (~> 0.1.2)
     awesome_print (1.2.0)
     coderay (1.1.0)
-    css_parser (1.3.6)
+    css_parser (1.3.7)
       addressable
     epubcheck (3.0.1)
     gepub (0.6.9.2)
@@ -37,7 +37,7 @@ GEM
     mini_portile (0.6.0)
     nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
-    pdf-core (0.5.1)
+    pdf-core (0.6.0)
     pdf-reader (1.3.3)
       Ascii85 (~> 1.0.0)
       afm (~> 0.2.0)
@@ -46,8 +46,8 @@ GEM
       ttfunk
     polyglot (0.3.5)
     posix-spawn (0.3.9)
-    prawn (2.0.1)
-      pdf-core (~> 0.5.1)
+    prawn (2.0.2)
+      pdf-core (~> 0.6.0)
       ttfunk (~> 1.4.0)
     prawn-icon (0.6.4)
       prawn (>= 1.1.0, < 3.0.0)
@@ -78,7 +78,7 @@ DEPENDENCIES
   asciidoctor (= 1.5.0)
   asciidoctor-epub3 (= 1.0.0.alpha.2)
   asciidoctor-pdf (= 1.5.0.alpha.8)
-  asciidoctor-pdf-cjk-kai_gen_gothic (~> 0.1.0)
+  asciidoctor-pdf-cjk-kai_gen_gothic (~> 0.1.1)
   awesome_print
   coderay
   epubcheck

--- a/Rakefile
+++ b/Rakefile
@@ -10,19 +10,19 @@ namespace :book do
   desc 'build basic book formats'
   task :build => :prebuild do
     puts "Converting to HTML..."
-    `bundle exec asciidoctor progit.asc`
+    `bundle exec asciidoctor -r ./config.rb progit.asc`
     puts " -- HTML output at progit.html"
 
     puts "Converting to EPub..."
-    `bundle exec asciidoctor-epub3 progit.asc`
+    `bundle exec asciidoctor-epub3 -r ./config.rb progit.asc`
     puts " -- Epub output at progit.epub"
 
     puts "Converting to Mobi (kf8)..."
-    `bundle exec asciidoctor-epub3 -a ebook-format=kf8 progit.asc`
+    `bundle exec asciidoctor-epub3 -r ./config.rb -a ebook-format=kf8 progit.asc`
     puts " -- Mobi output at progit.mobi"
 
     puts "Converting to PDF... (this one takes a while)"
-    `bundle exec asciidoctor-pdf -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicCN progit.asc 2>/dev/null`
+    `bundle exec asciidoctor-pdf -r ./config.rb -a pdf-style=KaiGenGothicCN progit.asc 2>/dev/null`
     puts " -- PDF  output at progit.pdf"
   end
 end

--- a/config.rb
+++ b/config.rb
@@ -1,0 +1,23 @@
+Bundler.require(:default)
+
+class TrailingTreeprocessor < Asciidoctor::Extensions::Treeprocessor
+  def process document
+    return unless document.blocks?
+    process_blocks document
+    nil
+  end
+
+  def process_blocks node
+    node.blocks.each_with_index do |block, index|
+      if block.context == :paragraph
+        node.blocks[index] = create_paragraph block.document, block.content.gsub("\n", ''), block.attributes
+      else
+        process_blocks block
+      end
+    end
+  end
+end
+
+Asciidoctor::Extensions.register do
+  treeprocessor TrailingTreeprocessor
+end


### PR DESCRIPTION
- 写了一个处理模块，解析文档后去掉多余的 `\n`，这会导致段落多出很多空格。
- 更新 PDF 主题，段落改为左对齐。原来的两段对齐会在空格处产生很多空白。

修改前：

![1](https://cloud.githubusercontent.com/assets/49931/10557975/8a6e7b06-74f2-11e5-8379-dcae52d76f99.png)

修改后：

![2](https://cloud.githubusercontent.com/assets/49931/10557976/910c23f0-74f2-11e5-8043-f7632ffafa92.png)

虽然左对齐没有两端对齐那么规整，但是能让换行产生的空白不那么突兀。

PS：更新了 asciidoctor-pdf-cjk-kai_gen_gothic 需要重新下载字体，但字体本身没有修改，为节约时间可以把旧版的字体拷到新版 gem 的 data/fonts 目录下。