### PR TITLE
为改善打印效果，修正了environment章节中的几处标点

### DIFF
--- a/book/10-git-internals/sections/environment.asc
+++ b/book/10-git-internals/sections/environment.asc
@@ -10,19 +10,19 @@ Git 总是在一个 `bash` shell 中运行，并借助一些 shell 环境变量�
 像通常的程序一样，Git 的常规行为依赖于环境变量。
 
 *`GIT_EXEC_PATH`* 决定 Git 到哪找它的子程序 （像 `git-commit`, `git-diff` 等等）。
-  你可以用 `git --exec-path` 来查看当前设置.
+  你可以用 `git --exec-path` 来查看当前设置。
 
 通常不会考虑修改 *`HOME`* 这个变量（太多其它东西都依赖它），这是 Git 查找全局配置文件的地方。
   如果你想要一个包括全局配置的真正的便携版 Git， 你可以在便携版 Git 的 shell 配置中覆盖 `HOME` 设置。
 
 *`PREFIX`* 也类似，除了用于系统级别的配置。
-  Git 在 `$PREFIX/etc/gitconfig` 查找此文件.
+  Git 在 `$PREFIX/etc/gitconfig` 查找此文件。
 
 如果设置了 *`GIT_CONFIG_NOSYSTEM`*，就禁用系统级别的配置文件。
   这在系统配置影响了你的命令，而你又无权限修改的时候很有用。
 
 *`GIT_PAGER`* 控制在命令行上显示多页输出的程序。
-如果这个没有设置，就会用 `PAGER` .
+如果这个没有设置，就会用 `PAGER` 。
 
 *`GIT_EDITOR`* 当用户需要编辑一些文本（比如提交信息）时， Git 会启动这个编辑器。
 如果没设置，就会用 `EDITOR` 。
@@ -32,20 +32,20 @@ Git 总是在一个 `bash` shell 中运行，并借助一些 shell 环境变量�
 
 Git 用了几个变量来确定它如何与当前版本库交互。
 
-*`GIT_DIR`* 是 `.git` 目录的位置.
+*`GIT_DIR`* 是 `.git` 目录的位置。
 如果这个没有设置， Git 会按照目录树逐层向上查找 `.git` 目录，直到到达 `~` 或 `/`。
 
 *`GIT_CEILING_DIRECTORIES`* 控制查找 `.git` 目录的行为。
 如果你访问加载很慢的目录（如那些磁带机上的或通过网络连接访问的），你可能会想让 Git 早点停止尝试，尤其是 shell 构建时调用了 Git 。
 
-*`GIT_WORK_TREE`* 是非空版本库的工作目录的根路径
+*`GIT_WORK_TREE`* 是非空版本库的工作目录的根路径。
 如果没指定，就使用 `$GIT_DIR` 的父目录。
 
-*`GIT_INDEX_FILE`* 是索引文件的路径（只有非空版本库有）
+*`GIT_INDEX_FILE`* 是索引文件的路径（只有非空版本库有）。
 
 *`GIT_OBJECT_DIRECTORY`* 用来指定 `.git/objects` 目录的位置。
 
-*`GIT_ALTERNATE_OBJECT_DIRECTORIES`* 一个冒号分割的列表 (格式类似 `/dir/one:/dir/two:…`) 用来告诉 Git 到哪里去找不在 `GIT_OBJECT_DIRECTORY` 目录中的对象.
+*`GIT_ALTERNATE_OBJECT_DIRECTORIES`* 一个冒号分割的列表 (格式类似 `/dir/one:/dir/two:…`) 用来告诉 Git 到哪里去找不在 `GIT_OBJECT_DIRECTORY` 目录中的对象。
 如果你有很多项目有相同内容的大文件，这个可以用来避免存储过多备份。
 
 
@@ -101,14 +101,14 @@ Git 使用 `curl` 库通过 HTTP来完成网络操作， 所以 *`GIT_CURL_VERBO
 
 ==== 比较和合并
 
-*`GIT_DIFF_OPTS`* 这个有点起错名字了
+*`GIT_DIFF_OPTS`* 这个有点起错名字了。
 有效值仅支持 `-u<n>` 或 `--unified=<n>`，用来控制在 `git diff` 命令中显示的内容行数。
 
 *`GIT_EXTERNAL_DIFF`* 用来覆盖 `diff.external` 配置的值。
-如果设置了这个值， 当执行Git `git diff` 时，Git 会调用该程序。
+如果设置了这个值， 当执行 `git diff` 时，Git 会调用该程序。
 
 *`GIT_DIFF_PATH_COUNTER`* 和 *`GIT_DIFF_PATH_TOTAL`* 对于 `GIT_EXTERNAL_DIFF` 或 `diff.external` 指定的程序有用。
-前者表示在一系列文件中哪个是被比较的（从 1 开始），后者表示每批文件的总数。 
+前者表示在一系列文件中哪个是被比较的（从 1 开始），后者表示每批文件的总数。
 
 *`GIT_MERGE_VERBOSITY`* 控制递归合并策略的输出。
 允许的值有下面这些：
@@ -120,15 +120,15 @@ Git 使用 `curl` 库通过 HTTP来完成网络操作， 所以 *`GIT_CURL_VERBO
 * 4 显示处理的所有路径。
 * 5 显示详细的调试信息。
 
-默认值是 2.
+默认值是 2。
 
 ==== 调试
 
 想 _真正地_ 知道 Git 正在做什么?
 Git 内置了相当完整的跟踪信息，你需要做的就是把它们打开。
-这些变量的可以用的值如下：
+这些变量的可用值如下：
 
-* ``true'', ``1'', 或 ``2'' – 跟踪类别写到标准错误输出.
+* ``true'', ``1'', 或 ``2'' – 跟踪类别写到标准错误输出。
 * 以 `/` 开头的绝对路径 – 跟踪输出会被写到那个文件。
 
 *`GIT_TRACE`* 控制常规跟踪，它并不适用于特殊情况。
@@ -145,7 +145,7 @@ $ GIT_TRACE=true git lga
 20:12:49.899675 run-command.c:192       trace: exec: 'less'
 ----
 
-*`GIT_TRACE_PACK_ACCESS`* 控制访问打包文件的跟踪信息
+*`GIT_TRACE_PACK_ACCESS`* 控制访问打包文件的跟踪信息。
 第一个字段是被访问的打包文件，第二个是文件的偏移量：
 
 [source,console]
@@ -162,7 +162,7 @@ Your branch is up-to-date with 'origin/master'.
 nothing to commit, working directory clean
 ----
 
-*`GIT_TRACE_PACKET`* 打开网络操作包级别的跟踪信息
+*`GIT_TRACE_PACKET`* 打开网络操作包级别的跟踪信息。
 
 [source,console]
 ----
@@ -198,7 +198,7 @@ Checking connectivity: 170994, done.
 20:18:25.233159 trace.c:414             performance: 6.112217000 s: git command: 'git' 'gc'
 ----
 
-*`GIT_TRACE_SETUP`* 显示 Git 发现的关于版本库和交互环境的信息
+*`GIT_TRACE_SETUP`* 显示 Git 发现的关于版本库和交互环境的信息。
 
 [source,console]
 ----
@@ -223,12 +223,12 @@ nothing to commit, working directory clean
 这是 Git 需要向用户请求验证时用到的程序，它接受一个文本提示作为命令行参数，并在 `stdout` 中返回应答。
 (查看 <<_credential_caching>>_ 访问更多相关内容)
 
-*`GIT_NAMESPACE`* 控制有命令空间的引用的访问，与 `--namespace` 标志是相同的.
+*`GIT_NAMESPACE`* 控制有命令空间的引用的访问，与 `--namespace` 标志是相同的。
 这主要在服务器端有用， 如果你想在一个版本库中存储单个版本库的多个 fork, 只要保持引用是隔离的就可以。
 
 *`GIT_FLUSH`* 强制 Git 在向标准输出增量写入时使用没有缓存的 I/O。
 设置为 1 让 Git 刷新更多， 设置为 0 则使所有的输出被缓存。
-默认值（若此变量未设置）是根据活动和输出模式的不同选择合适的缓存方案。 
+默认值（若此变量未设置）是根据活动和输出模式的不同选择合适的缓存方案。
 
 *`GIT_REFLOG_ACTION`* 让你可以指定描述性的文字写到 reflog 中。
 这有个例子：


### PR DESCRIPTION
此外：
1. 删除了＂当执行Git `git diff` 时，Git 会调用该程序＂中多余的第一个Git
2. 删除了几处行尾空格