### PR TITLE
修正有歧义的句子

### DIFF
--- a/book/07-git-tools/sections/revision-selection.asc
+++ b/book/07-git-tools/sections/revision-selection.asc
@@ -309,7 +309,7 @@ $ git log origin/master..HEAD
 ----
 
 这个命令会输出在你当前分支中而不在远程 `origin` 中的提交。
-如果你执行 `git push` 并且你的当前分支正在跟踪 `origin/master`，由 `git log origin/master..HEAD` 所输出的提交会被传输到远端服务器。
+如果你执行 `git push` 并且你的当前分支正在跟踪 `origin/master`，由 `git log origin/master..HEAD` 所输出的提交就是会被传输到远端服务器的提交。
 如果你留空了其中的一边， Git 会默认为 HEAD。
 例如， `git log origin/master..` 将会输出与之前例子相同的结果 —— Git 使用 HEAD 来代替留空的一边。
 


### PR DESCRIPTION
#373 
原文是: `If you run a git push and your current branch is tracking origin/master, the commits listed by git log origin/master..HEAD are the commits that will be transferred to the server.`，意思是运行 `git push` 命令时推送到远程服务器的提交，和运行 `git log origin/master..HEAD` 命令输出的提交是相同的。

而原译文中是: `如果你执行 git push 并且你的当前分支正在跟踪 origin/master，由 git log origin/master..HEAD 所输出的提交会被传输到远端服务器。`，这句意思是运行 `git log origin/master..HEAD` 所输出的提交会被传输到远端服务器。

原译文该句子有极大歧义，会误导读者。