### PR TITLE
修正翻译不准确的句子

### DIFF
--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -30,8 +30,8 @@ Git 也会给你一个与 origin 的 `master` 分支在指向同一个地方的�
 .克隆之后的服务器与本地仓库
 image::images/remote-branches-1.png[克隆之后的服务器与本地仓库。]
 
-如果你在本地的 `master` 分支做了一些工作，然而在同一时间，其他人推送提交到 `git.ourcompany.com` 并更新了它的 `master` 分支，那么你的提交历史将向不同的方向前进。
-也许，只要你不与 origin 服务器连接，你的 `origin/master` 指针就不会移动。
+如果你在本地的 `master` 分支做了一些工作，与此同时，其他人推送提交到 `git.ourcompany.com` 并更新了它的 `master` 分支，那么你的提交历史将向不同的方向前进。
+另外，只要你不与 origin 服务器连接，你的 `origin/master` 指针就不会移动。
 
 .本地与远程的工作可以分叉
 image::images/remote-branches-2.png[本地与远程的工作可以分叉。]


### PR DESCRIPTION
原文是：If you do some work on your local master branch, and, in the meantime, someone else pushes to git.ourcompany.com and updates its master branch, then your histories move forward differently. Also, as long as you stay out of contact with your origin server, your origin/master pointer doesn’t move.
在原译文中，有如下两个位置认为翻译的不够准确，不容易让人理解。
1. and, in the meantime, 原翻译为：然而在同一时间。这其中没有转折关系，而and作为连接词在此处完全可以不用翻译出来的。
2. Also, as long as，原翻译为：也许，只要……。根据前后文，这个也许实在是让人费解，并不是说明后者是前者的另一种可能性，所以认为此处应该换个词语来进行表达，翻译为：另外。

修改后的翻译为（*xx*标记出修改位置）：如果你在本地的 `master` 分支做了一些工作，*与此同时*，其他人推送提交到 `git.ourcompany.com` 并更新了它的 `master` 分支，那么你的提交历史将向不同的方向前进。
*另外*，只要你不与 origin 服务器连接，你的 `origin/master` 指针就不会移动。