### PR TITLE
翻译修正

### DIFF
--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -135,8 +135,8 @@ Switched to a new branch 'serverfix'
 如果在一个跟踪分支上输入 `git pull`，Git 能自动地识别去哪个服务器上抓取、合并到哪个分支。
 
 当克隆一个仓库时，它通常会自动地创建一个跟踪 `origin/master` 的 `master` 分支。
-然而，如果你愿意的话可以设置其他的跟踪分支 - 其他远程仓库上的跟踪分支，或者不跟踪 `master` 分支。
-最简单的就是之前看到的例子，运行 `git checkout -b [branch] [remotename]/[branch]`。
+然而，如果你愿意的话可以设置其他的跟踪分支，或是一个在其他远程仓库上的跟踪分支，又或者不跟踪 `master` 分支。
+最简单的实例就是像之前看到的那样，运行 `git checkout -b [branch] [remotename]/[branch]`。
 这是一个十分常用的操作所以 Git 提供了 `--track` 快捷方式：
 
 [source,console]

--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -30,8 +30,8 @@ Git 也会给你一个与 origin 的 `master` 分支在指向同一个地方的�
 .克隆之后的服务器与本地仓库
 image::images/remote-branches-1.png[克隆之后的服务器与本地仓库。]
 
-如果你在本地的 `master` 分支做了一些工作，然而在同一时间，其他人推送提交到 `git.ourcompany.com` 并更新了它的 `master` 分支，那么你的提交历史将向不同的方向前进。
-也许，只要你不与 origin 服务器连接，你的 `origin/master` 指针就不会移动。
+如果你在本地的 `master` 分支做了一些工作，与此同时，其他人推送提交到 `git.ourcompany.com` 并更新了它的 `master` 分支，那么你的提交历史将向不同的方向前进。
+另外，只要你不与 origin 服务器连接，你的 `origin/master` 指针就不会移动。
 
 .本地与远程的工作可以分叉
 image::images/remote-branches-2.png[本地与远程的工作可以分叉。]


### PR DESCRIPTION
我又来了。
文章原文是：However, you can set up other tracking branches if you wish — ones that track branches on other remotes, or don’t track the master branch. The simple case is the example you just saw, running git checkout -b <branch> <remote>/<branch>. 
同样认为翻译有两处不妥：
1. 从波折号开始，一直到句号，虽然说有的地方并没有转折词，但是都是列出来了跟踪其他分支的可能性，所以都是翻译成或是，又或是。
2. The simple case is the example you just saw,原翻译为：最简单的就是之前看到的例子。但是根据上下文感觉不是很通顺，中间有两个词都可以翻译为例子。经过上下文的多次考量，决定修改为：最简单的实例就是像之前看到的那样。
请多指教。第一次连续两次提交。