### PR TITLE
[fix] better translation of "Creative Commons"

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -7,7 +7,7 @@ image::https://travis-ci.org/progit/progit2-zh.svg?branch=master[]
 
 你可以访问 https://git-scm.com/book 在线阅读本书。
 
-与第一版类似，Pro Git 第二版以创作公用协议开源。
+与第一版类似，Pro Git 第二版以知识共享协议开源。
 
 自第一版开源以来，许多事情都发生了变化。
 首先，我们将本书的文本由 Markdown 迁移至 Asciidoc。


### PR DESCRIPTION
"Creative Commons" should be translated into "知识共享" by comparing, for example, https://creativecommons.org/choose/?lang=en and https://creativecommons.org/choose/?lang=zh