### PR TITLE
[fix]与英语原文保持一致

### DIFF
--- a/book/07-git-tools/sections/advanced-merging.asc
+++ b/book/07-git-tools/sections/advanced-merging.asc
@@ -348,7 +348,11 @@ Automatic merge failed; fix conflicts and then commit the result.
 #! /usr/bin/env ruby
 
 def hello
+<<<<<<< HEAD
+  puts 'hola world'
+=======
   puts 'hello mundo'
+>>>>>>> mundo
 end
 
 hello()
@@ -380,7 +384,13 @@ $ git checkout --conflict=diff3 hello.rb
 #! /usr/bin/env ruby
 
 def hello
+<<<<<<< ours
+  puts 'hola world'
+||||||| base
+  puts 'hello world'
+=======
   puts 'hello mundo'
+>>>>>>> theirs
 end
 
 hello()


### PR DESCRIPTION
今天在学习 [7.8 Git 工具 - 高级合并](https://git-scm.com/book/zh/v2/Git-%E5%B7%A5%E5%85%B7-%E9%AB%98%E7%BA%A7%E5%90%88%E5%B9%B6) 的时候，学到 [检出冲突](https://git-scm.com/book/zh/v2/Git-%E5%B7%A5%E5%85%B7-%E9%AB%98%E7%BA%A7%E5%90%88%E5%B9%B6#_checking_out_conflicts) 这里，有一段描述是输出一段冲突未解决的代码，但在文章中并看不出来冲突在哪里。想了一想不太对劲，于是拿出英文版来看，发现这里的冲突被删除了。然后我发现在 [这次合并](https://github.com/progit/progit2-zh/commit/55d47a577a67b2638ffb8f1a10f6d599608d55a7) 中将代码给替换掉了。

> 第一次提交 PR ，如有错误，请多多指出。