### PR TITLE
Translate go-git’s sections & update go-git's Github address

### DIFF
--- a/book/B-embedding-git/sections/go-git.asc
+++ b/book/B-embedding-git/sections/go-git.asc
@@ -1,13 +1,12 @@
 === go-git
 
 (((go-git)))(((Go)))
-In case you want to integrate Git into a service written in Golang, there also is a pure Go library implementation.
-This implementation does not have any native dependencies and thus is not prone to manual memory management errors.
-It is also transparent for the standard Golang performance analysis tooling like CPU, Memory profilers, race detector, etc.
+如果你想将 Git 集成到用 Golang 编写的服务中，这里还有一个纯 Go 库的实现。这个库的实现没有任何原生依赖，因此不易出现手动管理内存的错误。
+它对于标准 Golang 性能分析工具（如 CPU、内存分析器、竞争检测器等）也是透明的。
 
-go-git is focused on extensibility, compatibility and supports most of the plumbing APIs, which is documented at https://github.com/src-d/go-git/blob/master/COMPATIBILITY.md[].
+go-git 专注于可扩展性、兼容性并支持大多数管道 API，记录在 https://github.com/src-d/go-git/blob/master/COMPATIBILITY.md[].
 
-Here is a basic example of using Go APIs:
+以下是使用 Go API 的基本示例：
 
 [source, go]
 -----
@@ -19,31 +18,31 @@ r, err := git.PlainClone("/tmp/foo", false, &git.CloneOptions{
 })
 -----
 
-As soon as you have a `Repository` instance, you can access information and perform mutations on it:
+你只要拥有一个 `Repository` 实例，就可以访问相应仓库信息并对其进行改变：
 
 
 [source, go]
 -----
-// retrieves the branch pointed by HEAD
+// 获取 HEAD 指向的分支
 ref, err := r.Head()
 
-// get the commit object, pointed by ref
+// 获取由 ref 指向的提交对象
 commit, err := r.CommitObject(ref.Hash())
 
-// retrieves the commit history
+// 检索提交历史
 history, err := commit.History()
 
-// iterates over the commits and print each
+// 遍历并逐个打印提交
 for _, c := range history {
     fmt.Println(c)
 }
 -----
 
 
-==== Advanced Functionality
+==== 高级功能
 
-go-git has few notable advanced features, one of which is a pluggable storage system, which is similar to Libgit2 backends.
-The default implementation is in-memory storage, which is very fast.
+go-git 几乎没有值得注意的高级功能，其中之一是可插拔存储系统，类似于 Libgit2 后端。
+默认实现是内存存储，速度非常快。
 
 [source, go]
 -----
@@ -52,35 +51,36 @@ r, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
 })
 -----
 
-Pluggable storage provides many interesting options.
-For instance, https://github.com/src-d/go-git/tree/master/_examples/storage[] allows you to store references, objects, and configuration in an Aerospike database.
+可插拔存储提供了许多有趣的选项。
+例如，https://github.com/src-d/go-git/tree/master/_examples/storage[] 允许你在 Aerospike 数据库中存储引用、对象和配置。
 
-Another feature is a flexible filesystem abstraction.
-Using https://godoc.org/github.com/src-d/go-billy#Filesystem[] it is easy to store all the files in different way i.e by packing all of them to a single archive on disk or by keeping them all in-memory.
+另一个特性是灵活的文件系统抽象。
+使用 https://godoc.org/github.com/src-d/go-billy#Filesystem[] 
+可以很容易以不同的方式存储所有文件，即通过将所有文件打包到磁盘上的单个归档文件或保存它们都在内存中。
 
-Another advanced use-case includes a fine-tunable HTTP client, such as the one found at https://github.com/src-d/go-git/blob/master/_examples/custom_http/main.go[].
+另一个高级用例包括一个可微调的 HTTP 客户端，例如 https://github.com/src-d/go-git/blob/master/_examples/custom_http/main.go[] 中的案例。
 
 [source, go]
 -----
 customClient := &http.Client{
-	Transport: &http.Transport{ // accept any certificate (might be useful for testing)
+	Transport: &http.Transport{ // 接受任何证书（可能对测试有用）
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	},
-	Timeout: 15 * time.Second,  // 15 second timeout
+	Timeout: 15 * time.Second,  // 15 秒超时
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-		return http.ErrUseLastResponse // don't follow redirect
+		return http.ErrUseLastResponse // 不要跟随重定向
 	},
 }
 
-// Override http(s) default protocol to use our custom client
+// 覆盖 http(s) 默认协议以使用我们的自定义客户端
 client.InstallProtocol("https", githttp.NewClient(customClient))
 
-// Clone repository using the new client if the protocol is https://
+// 如果协议为 https://，则使用新客户端克隆存储库
 r, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{URL: url})
 -----
 
 
-==== Further Reading
+==== 延伸阅读
 
-A full treatment of go-git's capabilities is outside the scope of this book.
-If you want more information on go-git, there's API documentation at https://godoc.org/gopkg.in/src-d/go-git.v4[], and a set of usage examples at https://github.com/src-d/go-git/tree/master/_examples[].
+对 go-git 功能的全面介绍超出了本书的范围。
+如果您想了解有关 go-git 的更多信息，请参阅 https://godoc.org/gopkg.in/src-d/go-git.v4[] 上的 API 文档， 以及 https://github.com/src-d/go-git/tree/master/_examples[] 上的系列使用示例。

--- a/book/B-embedding-git/sections/go-git.asc
+++ b/book/B-embedding-git/sections/go-git.asc
@@ -4,7 +4,7 @@
 如果你想将 Git 集成到用 Golang 编写的服务中，这里还有一个纯 Go 库的实现。这个库的实现没有任何原生依赖，因此不易出现手动管理内存的错误。
 它对于标准 Golang 性能分析工具（如 CPU、内存分析器、竞争检测器等）也是透明的。
 
-go-git 专注于可扩展性、兼容性并支持大多数管道 API，记录在 https://github.com/src-d/go-git/blob/master/COMPATIBILITY.md[].
+go-git 专注于可扩展性、兼容性并支持大多数管道 API，记录在 https://github.com/go-git/go-git/blob/master/COMPATIBILITY.md[].
 
 以下是使用 Go API 的基本示例：
 
@@ -52,13 +52,13 @@ r, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
 -----
 
 可插拔存储提供了许多有趣的选项。
-例如，https://github.com/src-d/go-git/tree/master/_examples/storage[] 允许你在 Aerospike 数据库中存储引用、对象和配置。
+例如，https://github.com/go-git/go-git/tree/master/_examples/storage[] 允许你在 Aerospike 数据库中存储引用、对象和配置。
 
 另一个特性是灵活的文件系统抽象。
 使用 https://godoc.org/github.com/src-d/go-billy#Filesystem[] 
 可以很容易以不同的方式存储所有文件，即通过将所有文件打包到磁盘上的单个归档文件或保存它们都在内存中。
 
-另一个高级用例包括一个可微调的 HTTP 客户端，例如 https://github.com/src-d/go-git/blob/master/_examples/custom_http/main.go[] 中的案例。
+另一个高级用例包括一个可微调的 HTTP 客户端，例如 https://github.com/go-git/go-git/blob/master/_examples/custom_http/main.go[] 中的案例。
 
 [source, go]
 -----
@@ -83,4 +83,4 @@ r, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{URL: url})
 ==== 延伸阅读
 
 对 go-git 功能的全面介绍超出了本书的范围。
-如果您想了解有关 go-git 的更多信息，请参阅 https://godoc.org/gopkg.in/src-d/go-git.v4[] 上的 API 文档， 以及 https://github.com/src-d/go-git/tree/master/_examples[] 上的系列使用示例。
+如果您想了解有关 go-git 的更多信息，请参阅 https://godoc.org/gopkg.in/src-d/go-git.v4[] 上的 API 文档， 以及 https://github.com/go-git/go-git/tree/master/_examples[] 上的系列使用示例。

--- a/book/B-embedding-git/sections/go-git.asc
+++ b/book/B-embedding-git/sections/go-git.asc
@@ -1,7 +1,8 @@
 === go-git
 
 (((go-git)))(((Go)))
-如果你想将 Git 集成到用 Golang 编写的服务中，这里还有一个纯 Go 库的实现。这个库的实现没有任何原生依赖，因此不易出现手动管理内存的错误。
+如果你想将 Git 集成到用 Golang 编写的服务中，这里还有一个纯 Go 库的实现。
+这个库的实现没有任何原生依赖，因此不易出现手动管理内存的错误。
 它对于标准 Golang 性能分析工具（如 CPU、内存分析器、竞争检测器等）也是透明的。
 
 go-git 专注于可扩展性、兼容性并支持大多数管道 API，记录在 https://github.com/go-git/go-git/blob/master/COMPATIBILITY.md[].
@@ -55,8 +56,7 @@ r, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
 例如，https://github.com/go-git/go-git/tree/master/_examples/storage[] 允许你在 Aerospike 数据库中存储引用、对象和配置。
 
 另一个特性是灵活的文件系统抽象。
-使用 https://godoc.org/github.com/src-d/go-billy#Filesystem[] 
-可以很容易以不同的方式存储所有文件，即通过将所有文件打包到磁盘上的单个归档文件或保存它们都在内存中。
+使用 https://godoc.org/github.com/src-d/go-billy#Filesystem[] 可以很容易以不同的方式存储所有文件，即通过将所有文件打包到磁盘上的单个归档文件或保存它们都在内存中。
 
 另一个高级用例包括一个可微调的 HTTP 客户端，例如 https://github.com/go-git/go-git/blob/master/_examples/custom_http/main.go[] 中的案例。
 


### PR DESCRIPTION
Translate `book/B-embedding-git/sections/go-git.asc` into Chinese which include:

- Full translation of full text
- Since the go-git project has been moved to https://github.com/src-d/go-git/ to https://github.com/go-git/go-git , update the link address in the original text and translation

---

将 `book/B-embedding-git/sections/go-git.asc` 翻译成中文，包括：

- 全文完整的翻译
- 由于 go-git 项目已从 https://github.com/src-d/go-git/ 迁移至 https://github.com/go-git/go-git ，更新原文和译文中的链接地址