### PR TITLE
使用asciidoctor插件时link修复

### DIFF
--- a/C-git-commands.asc
+++ b/C-git-commands.asc
@@ -42,7 +42,7 @@ Git 做的很多工作都有一种默认方式。
 
 最后，基本上 <<ch08-customizing-git#_git_config>> 整个章节都是针对此命令的。
 
-[[_core_editor]]
+[[ch_core_editor]]
 ==== git config core.editor 命令
 
 就像 <<ch01-getting-started#_first_time>> 里的设置指示，很多编辑器可以如下设置：

--- a/book/01-introduction/sections/first-time-setup.asc
+++ b/book/01-introduction/sections/first-time-setup.asc
@@ -77,7 +77,7 @@ $ git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -m
 ====
 Vim、Emacs 和 Notepad++ 都是流行的文本编辑器，通常程序员们会在 Linux 和 macOS
 这类基于 Unix 的系统或 Windows 系统上使用它们。
-如果你在使用其他的或 32 位版本的编辑器，请在 <<C-git-commands#_core_editor>>
+如果你在使用其他的或 32 位版本的编辑器，请在 <<C-git-commands#ch_core_editor>>
 中查看设置为该编辑器的具体步骤。
 ====
 

--- a/progit.asc
+++ b/progit.asc
@@ -1,5 +1,4 @@
-Pro Git
-=======
+= Pro Git
 Scott Chacon; Ben Straub
 :doctype: book
 :docinfo:


### PR DESCRIPTION
使用asciidoctor-vscode插件，或者chrome浏览器插件时，浏览progit.asc时，必须修正如下内容，否则无法正确链接