### PR TITLE
Fix quotation marks

### DIFF
--- a/book/03-git-branching/sections/remote-branches.asc
+++ b/book/03-git-branching/sections/remote-branches.asc
@@ -42,7 +42,7 @@ image::images/remote-branches-1.png[克隆之后的服务器与本地仓库。]
 image::images/remote-branches-2.png[本地与远程的工作可以分叉。]
 
 如果要与给定的远程仓库同步数据，运行 `git fetch <remote>` 命令（在本例中为 `git fetch origin`）。
-这个命令查找 ``origin'' 是哪一个服务器（在本例中，它是 `git.ourcompany.com`），
+这个命令查找 “origin” 是哪一个服务器（在本例中，它是 `git.ourcompany.com`），
 从中抓取本地没有的数据，并且更新本地数据库，移动 `origin/master` 指针到更新之后的位置。
 
 .`git fetch` 更新你的远程跟踪分支


### PR DESCRIPTION
本书 PDF 版本第三章「Git 分支」中的「远程分支」一节（P87）存在引号错误，如下图所示：

![P87引号错误](https://github.com/progit/progit2-zh/assets/12986481/61e15e1b-fc5f-40b1-86b5-f4ea261ed92f)

其原文为：

```markdown
This command looks up which server "`origin`" is
```

https://github.com/progit/progit2/blob/1b6b9cd888db33c842339dfec7b3c44989ece744/book/03-git-branching/sections/remote-branches.asc?plain=1#L40

由于上文将原文中的：

```markdown
."`origin`" is not special
```

https://github.com/progit/progit2/blob/1b6b9cd888db33c842339dfec7b3c44989ece744/book/03-git-branching/sections/remote-branches.asc?plain=1#L23

译为：

```markdown
.“origin” 并无特殊含义
```

https://github.com/progit/progit2-zh/blob/a7baa05fc387333be21e3fe014d85a50b147e237/book/03-git-branching/sections/remote-branches.asc?plain=1#L26

为了与上文的引号用法保持一致，将此处引号修改为：

```markdown
这个命令查找 “origin” 是哪一个服务器
```
