### PR TITLE
Fix escape character and figure title

### DIFF
--- a/book/07-git-tools/sections/revision-selection.asc
+++ b/book/07-git-tools/sections/revision-selection.asc
@@ -276,7 +276,7 @@ Date:   Fri Nov 7 13:47:59 2008 -0500
     ignore *.gem
 ----
 
-也可以写成 `HEAD~~~`，也是第一父提交的第一父提交的第一父提交：
+也可以写成 `HEAD\~~~`，也是第一父提交的第一父提交的第一父提交：
 
 [source,console]
 ----
@@ -301,10 +301,10 @@ Date:   Fri Nov 7 13:47:59 2008 -0500
 
 最常用的指明提交区间语法是双点。
 这种语法可以让 Git 选出在一个分支中而不在另一个分支中的提交。
-例如，你有如下的提交历史 <<double_dot>>
+例如，假设你的提交历史类似于 <<double_dot>>。
 
 [[double_dot]]
-.Example history for range selection.
+.区间选择的提交历史示例
 image::images/double-dot.png[区间选择的提交历史示例]
 
 你想要查看 experiment 分支中还有哪些提交尚未被合并入 master 分支。


### PR DESCRIPTION
本书 PDF 版本第七章「Git 工具」中的「选择修订版本」一节（P222）存在转义字符错误和图标题错误，如下图所示：

![转义字符](https://github.com/progit/progit2-zh/assets/12986481/84dffe6a-39ac-4350-89fd-03b954781fd1)

![图标题](https://github.com/progit/progit2-zh/assets/12986481/24ed2728-dbac-4098-966f-8c388837ba90)

对应的原文如下：

[转义字符](https://github.com/progit/progit2/blob/be823c3a1922854126d6e2d2ca3e13c50ca0ee15/book/07-git-tools/sections/revision-selection.asc?plain=1#L283)

[图标题](https://github.com/progit/progit2/blob/be823c3a1922854126d6e2d2ca3e13c50ca0ee15/book/07-git-tools/sections/revision-selection.asc?plain=1#L310)

为了使语句更加通顺，调整了以下翻译。

[原文](https://github.com/progit/progit2/blob/be823c3a1922854126d6e2d2ca3e13c50ca0ee15/book/07-git-tools/sections/revision-selection.asc?plain=1#L307)：
```markdown
For example, say you have a commit history that looks like Example history for range selection.
```

调整前：
```markdown
例如，你有如下的提交历史 区间选择的提交历史示例
```

调整后：
```markdown
例如，假设你的提交历史类似于 区间选择的提交历史示例。
```
