### PR TITLE
Update refspec.asc

### DIFF
--- a/book/10-git-internals/sections/refspec.asc
+++ b/book/10-git-internals/sections/refspec.asc
@@ -80,14 +80,14 @@ From git@github.com:schacon/simplegit
 	fetch = +refs/heads/experiment:refs/remotes/origin/experiment
 ----
 
-我们不能在模式中使用部分通配符，所以像下面这样的引用规范是不合法的：
+自 Git 2.6.0 起可以在模式中使用部分通配符以匹配多个分支，所以这样是可以工作的：
 
 [source,ini]
 ----
 fetch = +refs/heads/qa*:refs/remotes/origin/qa*
 ----
 
-但我们可以使用命名空间（或目录）来达到类似目的。
+更棒的是，我们可以使用命名空间（或目录）来实现相同的目标，并且更具结构性。
 假设你有一个 QA 团队，他们推送了一系列分支，同时你只想要获取 `master` 和
 QA 团队的所有分支而不关心其他任何分支，那么可以使用如下配置：
 


### PR DESCRIPTION
Sync with English version about partial globs:

```
Since Git 2.6.0 you can use partial globs in the pattern to match multiple branches, so this works:
```

```
Even better, you can use namespaces (or directories) to accomplish the same with more structure. 
```