### PR TITLE
Fixes #492 更正辅助工具git-credential-read-only的输入

### DIFF
--- a/book/07-git-tools/sections/credentials.asc
+++ b/book/07-git-tools/sections/credentials.asc
@@ -187,6 +187,7 @@ include::../git-credential-read-only[]
 $ git credential-read-only --file=/mnt/shared/creds get
 protocol=https
 host=mygithost
+username=bob
 
 protocol=https
 host=mygithost


### PR DESCRIPTION
Fixes #492 
更正辅助工具git-credential-read-only的输入