### PR TITLE
Fixes #498 增加附录A：Git in bash缺少的翻译

### DIFF
--- a/book/A-git-in-other-environments/sections/bash.asc
+++ b/book/A-git-in-other-environments/sections/bash.asc
@@ -4,8 +4,9 @@
 如果你是一名 Bash 用户，你可以从中发掘出一些 Shell 的特性，让你在使用 Git 时更加随心所欲。
 实际上 Git 附带了几个 Shell 的插件，但是这些插件并不是默认打开的。
 
-首先，你需要从 Git 源代码中获得一份 `contrib/completion/git-completion.bash` 文件的拷贝。
-将这个文件复制到一个相对便捷的目录，例如你的 Home 目录，并且将它的路径添加到 `.bashrc` 中：
+首先，你需要从你使用的 Git 发行版的源代码中获得一份自动补全文件的拷贝。
+输入 `git version` 检查版本，然后使用 `git checkout tags/vX.Y.Z`，其中 `vX.Y.Z` 对应于你正在使用的 Git 版本。
+将这个 `contrib/completion/git-completion.bash` 文件复制到一个相对便捷的目录，例如你的 Home 目录，并且将它的路径添加到 `.bashrc` 中：
 
 [source,console]
 -----


### PR DESCRIPTION
Fixes #498 
修改内容：
- 增加缺少的翻译
- 依照原文对前后文翻译进行修改