### PR TITLE
Fixes #514 修改附录A：guis中翻译与原文不一致的格式

### DIFF
--- a/book/A-git-in-other-environments/sections/guis.asc
+++ b/book/A-git-in-other-environments/sections/guis.asc
@@ -66,8 +66,6 @@ image::images/git-gui.png[`git-gui` 提交工具。]
 `gitk` 和 `git-gui` 就是针对某种任务设计的工具的两个例子。
 它们分别为了不同的目的（即查看历史和制作提交）而进行了精简，略去了用不到的功能。
 
-==== GitHub for macOS and Windows
-
 ==== macOS 和 Windows 上的 GitHub 客户端
 
 (((GitHub for macOS)))(((GitHub for Windows)))
@@ -98,7 +96,7 @@ image::images/github_win.png[GitHub Windows 客户端。]
 
 ===== 安装
 
-GitHub 的 Windows 客户端可以从 https://windows.github.com[] 下载，macOS 客户端可以从 https://mac.github.com[]下载。
+GitHub 的 Windows 客户端可以从 https://windows.github.com[] 下载，macOS 客户端可以从 https://mac.github.com[] 下载。
 第一次打开软件时，它会引导你进行一系列的首次使用设置，例如设置你的姓名和电子邮件，它还会智能地帮你调整一些常用的默认设置，例如凭证缓存和 CRLF 的处理方式。
 
 它们都是“绿色软件”——如果软件打开发现有更新，下载和安装升级包都是在后台完成的。
@@ -146,9 +144,8 @@ push，fetch，merge，和 rebase 在 Git 内部是一连串独立的操作, 而
 开发者和非开发者可以轻松地在分分钟内就搭建起项目协作环境，它们还内置了其它辅助最佳实践的功能。
 但是，如果你的工作流程有所不同，或者你需要在进行网络操作时有更多的控制，那么建议你考虑一下其它客户端或者使用命令行。
 
-
 ==== 其它图形界面
 
 除此之外，还有许许多多其它的图形化 Git 客户端，其中既有单一功能的定制工具，也有试图提供 Git 所有功能的复杂应用。
 Git 的官方网站整理了一份时下最流行的客户端的清单 https://git-scm.com/downloads/guis[]。
-在 Git 的维基站点还可以看到一份更全的清单 https://git.wiki.kernel.org/index.php/Interfaces,_frontends,_and_tools#Graphical_Interfaces[].
+在 Git 的维基站点还可以看到一份更全的清单 https://git.wiki.kernel.org/index.php/Interfaces,_frontends,_and_tools#Graphical_Interfaces[]。


### PR DESCRIPTION
Fixes #514 

## 问题：
- 翻译后还有原文目录
- 链接与中文之间缺空格
- 连续空行
- 句号是英文的