### PR TITLE
Fixes #517 修改git-credential-read-only ruby脚本过时的代码

### DIFF
--- a/book/07-git-tools/git-credential-read-only
+++ b/book/07-git-tools/git-credential-read-only
@@ -11,7 +11,7 @@ OptionParser.new do |opts|
 end.parse!
 
 exit(0) unless ARGV[0].downcase == 'get' # <2>
-exit(0) unless File.exists? path
+exit(0) unless File.exist? path
 
 known = {} # <3>
 while line = STDIN.gets


### PR DESCRIPTION
Fixes #517 

修改ruby scripts git-credential-read-only: File.exists? to File.exist?
https://github.com/progit/progit2/pull/1974#issue-2462218819

代码过时原因：
https://github.com/progit/progit2/issues/1969#issuecomment-2284670036