### PR TITLE
GitHub Actions: Deprecating set-output commands

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -17,8 +17,8 @@ jobs:
         echo Computing next tag number
         LASTPATCH=$(git describe --tags | cut -d- -f1 | cut -d. -f3)
         PATCH=$(($LASTPATCH+1))
-        echo "::set-output name=tagname::2.1.${PATCH}"
-        echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
+        echo "tagname=2.1.${PATCH}" >> $GITHUB_OUTPUT
+        echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1


### PR DESCRIPTION
解决这个警告：
![image](https://github.com/user-attachments/assets/3c5e7d58-b068-40d6-9ab1-130ab93e75f0)

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/