### PR TITLE
Fix translation of title "Git in PowerShell" to maintain consistency

### DIFF
--- a/book/A-git-in-other-environments/sections/powershell.asc
+++ b/book/A-git-in-other-environments/sections/powershell.asc
@@ -1,5 +1,5 @@
 [[_git_powershell]]
-=== Git 在 PowerShell 中使用 Git
+=== PowerShell 中的 Git
 
 (((PowerShell)))(((tab completion, PowerShell)))(((shell prompts, PowerShell)))
 (((posh-git)))


### PR DESCRIPTION
As "Git in Bash" is translated to "Bash 中的 Git", "Git in Zsh" is translated to "Zsh 中的 Git", "Git in Powershell" should be translated to "Powershell 中的 Git" to maintain consistency.