### PR TITLE
修复2.4Git-基础-撤消操作中两个连字符--被渲染成了一个长破折号—

### DIFF
--- a/book/02-git-basics/sections/undoing.asc
+++ b/book/02-git-basics/sections/undoing.asc
@@ -131,7 +131,7 @@ Changes to be committed:
 
 [IMPORTANT]
 =====
-请务必记得 `git checkout -- <file>` 是一个危险的命令。
+请务必记得 `git checkout \-- <file>` 是一个危险的命令。
 你对那个文件在本地的任何修改都会消失——Git 会用最近提交的版本覆盖掉它。
 除非你确实清楚不想要对那个文件的本地修改了，否则请不要使用这个命令。
 =====


### PR DESCRIPTION
#536